### PR TITLE
FIX wrong return types in docstrings

### DIFF
--- a/skglm/solvers/cd_solver.py
+++ b/skglm/solvers/cd_solver.py
@@ -214,14 +214,14 @@ def cd_solver(
 
     Returns
     -------
-    alphas : array, shape (n_alphas,)
-        The alphas along the path where models are computed.
-
     coefs : array, shape (n_features, n_alphas)
         Coefficients along the path.
 
-    stop_crit : array, shape (n_alphas,)
-        Value of stopping criterion at convergence along the path.
+    obj_out : array, shape (n_iter,)
+        The objective values at every outer iteration.
+
+    stop_crit : float
+        Value of stopping criterion at convergence.
     """
     if ws_strategy not in ("subdiff", "fixpoint"):
         raise ValueError(f'Unsupported value for ws_strategy: {ws_strategy}')

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -194,14 +194,14 @@ def bcd_solver(
 
     Returns
     -------
-    alphas : array, shape (n_alphas,)
-        The alphas along the path where models are computed.
-
     coefs : array, shape (n_features, n_tasks, n_alphas)
         Coefficients along the path.
 
-    stop_crit : array, shape (n_alphas,)
-        Value of stopping criterion at convergence along the path.
+    obj_out : array, shape (n_iter,)
+        The objective values at every outer iteration.
+
+    stop_crit : float
+        Value of stopping criterion at convergence.
     """
     n_tasks = Y.shape[1]
     n_features = X.shape[1]


### PR DESCRIPTION
While reviewing #26 I found that the docstrings for `cd_solver` and `bcd_solver` were wrong. I fixed it.