### PR TITLE
[WIP] ENH - Handle low rank residual matrix in ``AndersonAcceleration``

### DIFF
--- a/debug_script.py
+++ b/debug_script.py
@@ -1,0 +1,48 @@
+r"""Example with:
+
+u_{n+1} = \begin{cases}
+            u_{n}            & if n \bmod 3
+            \rho u_{n} + b   & otherwise
+          \end{cases}
+"""
+import numpy as np
+from numpy.linalg import norm
+
+from debug_script_utils import AA_singular, AA_usual
+
+
+def assess_AA(aa_class):
+    max_iter, tol = 1000, 1e-9
+    n_features = 5
+    X = np.eye(n_features)
+
+    b = 1
+    np.random.seed(0)
+    rho = np.random.rand(n_features)
+    w_star = b / (1 - rho)
+
+    accelerator = aa_class(K=5)
+    w = np.ones(n_features)
+    Xw = X @ w
+    for i in range(max_iter):
+        w, Xw = accelerator.extrapolate(w, Xw)
+        if i % 3:
+            w = rho * w + b
+            Xw = X @ w
+
+        stop_crit = norm(w - w_star, ord=np.inf)
+        if stop_crit < tol:
+            break
+
+    return stop_crit, i
+
+
+if __name__ == '__main__':
+    stop_crit, n_iter = assess_AA(AA_usual)
+    print(f"usual AA: {stop_crit} , iter {n_iter}")
+
+    print("********************")
+    print("********************")
+
+    stop_crit, n_iter = assess_AA(AA_singular)
+    print(f"singular AA : {stop_crit} , iter {n_iter}")

--- a/debug_script_utils.py
+++ b/debug_script_utils.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+
+class AA_singular:
+    """Abstraction of Anderson Acceleration.
+
+    Extrapolate the asymptotic VAR ``w`` and ``Xw``
+    based on ``K`` previous iterations.
+
+    Parameters
+    ----------
+    K : int
+        Number of previous iterates to consider for extrapolation.
+    """
+
+    def __init__(self, K):
+        self.K, self.current_iter = K, 0
+        self.arr_w_, self.arr_Xw_ = None, None
+
+    def extrapolate(self, w, Xw):
+        """Return ``w``, ``Xw``, and a bool indicating wether they were extrapolated."""
+        if self.arr_w_ is None or self.arr_Xw_ is None:
+            self.arr_w_ = np.zeros((w.shape[0], self.K+1))
+            self.arr_Xw_ = np.zeros((Xw.shape[0], self.K+1))
+
+        if self.current_iter <= self.K:
+            self.arr_w_[:, self.current_iter] = w
+            self.arr_Xw_[:, self.current_iter] = Xw
+            self.current_iter += 1
+            return w, Xw
+
+        U = np.diff(self.arr_w_, axis=1)  # compute residuals
+
+        # compute extrapolation coefs
+        inv_UTU_ones, n_K_excluded = self.solve_UTU_ones(U.T @ U)
+        C = inv_UTU_ones / np.sum(inv_UTU_ones)
+
+        # extrapolate
+        w_acc = self.arr_w_[:, 1+n_K_excluded:] @ C
+        Xw_acc = self.arr_Xw_[:, 1+n_K_excluded:] @ C
+
+        self.current_iter = 0  # reset counter
+        return w_acc, Xw_acc
+
+    def solve_UTU_ones(self, UTU):
+        """Solve ``UTU = I`` while handing the singularity case.
+
+        Returns solution and number of excluded iters.
+        """
+        dim_UTU = UTU.shape[0]
+
+        if dim_UTU == 1 and UTU[0, 0] == 0:
+            return np.ones(1), self.K - 1
+
+        try:
+            inv_UTU_ones = np.linalg.solve(UTU, np.ones(dim_UTU))
+        except np.linalg.LinAlgError:
+            return self.solve_UTU_ones(UTU[:-1, :-1])
+
+        return inv_UTU_ones, self.K - dim_UTU
+
+
+class AA_usual:
+    """Abstraction of Anderson Acceleration.
+
+    Extrapolate the asymptotic VAR ``w`` and ``Xw``
+    based on ``K`` previous iterations.
+
+    Parameters
+    ----------
+    K : int
+        Number of previous iterates to consider for extrapolation.
+    """
+
+    def __init__(self, K):
+        self.K, self.current_iter = K, 0
+        self.arr_w_, self.arr_Xw_ = None, None
+
+    def extrapolate(self, w, Xw):
+        """Return ``w`` and ``Xw`` extrapolated."""
+        if self.arr_w_ is None or self.arr_Xw_ is None:
+            self.arr_w_ = np.zeros((w.shape[0], self.K+1))
+            self.arr_Xw_ = np.zeros((Xw.shape[0], self.K+1))
+
+        if self.current_iter <= self.K:
+            self.arr_w_[:, self.current_iter] = w
+            self.arr_Xw_[:, self.current_iter] = Xw
+            self.current_iter += 1
+            return w, Xw
+
+        U = np.diff(self.arr_w_, axis=1)  # compute residuals
+
+        # compute extrapolation coefs
+        try:
+            inv_UTU_ones = np.linalg.solve(U.T @ U, np.ones(self.K))
+        except np.linalg.LinAlgError:
+            return w, Xw
+        finally:
+            self.current_iter = 0
+
+        # extrapolate
+        C = inv_UTU_ones / np.sum(inv_UTU_ones)
+        # floating point errors may cause w and Xw to disagree
+        return self.arr_w_[:, 1:] @ C, self.arr_Xw_[:, 1:] @ C

--- a/skglm/solvers/group_bcd_solver.py
+++ b/skglm/solvers/group_bcd_solver.py
@@ -64,7 +64,11 @@ def bcd_solver(X, y, datafit, penalty, w_init=None, p0=10,
     datafit.initialize(X, y)
     all_groups = np.arange(n_groups)
     p_objs_out = np.zeros(max_iter)
-    stop_crit = 0.  # prevent ref before assign when max_iter == 0
+
+    # prevent ref before assign when max_iter == 0
+    p_obj = datafit.value(y, w, Xw) + penalty.value(w)
+    stop_crit = 0.
+
     accelerator = AndersonAcceleration(K=5)
 
     for t in range(max_iter):
@@ -92,6 +96,7 @@ def bcd_solver(X, y, datafit, penalty, w_init=None, p0=10,
             _bcd_epoch(X, y, w, Xw, datafit, penalty, ws)
 
             w_acc, Xw_acc = accelerator.extrapolate(w, Xw)
+
             p_obj = datafit.value(y, w, Xw) + penalty.value(w)
             p_obj_acc = datafit.value(y, w_acc, Xw_acc) + penalty.value(w_acc)
 

--- a/skglm/utils.py
+++ b/skglm/utils.py
@@ -273,7 +273,7 @@ class AndersonAcceleration:
         self.arr_w_, self.arr_Xw_ = None, None
 
     def extrapolate(self, w, Xw):
-        """Return ``w`` and ``Xw`` extrapolated."""
+        """Return ``w``, ``Xw``, and a bool indicating wether they were extrapolated."""
         if self.arr_w_ is None or self.arr_Xw_ is None:
             self.arr_w_ = np.zeros((w.shape[0], self.K+1))
             self.arr_Xw_ = np.zeros((Xw.shape[0], self.K+1))


### PR DESCRIPTION
This aims to handle the case of singular residual matrix in ``AndersonAccelration`` class

According to [Dual Extrapolation for Sparse Generalized Linear Models](https://arxiv.org/abs/1907.05830) (cf. Proposition 7),
if the matrix of residuals is not full rank (`U.T @ U` singular) then we can extrapolate using the K-1 previous iteration.

The following proposes an implementation of this. It will proceed as follow

- [x] handle the case of singular `U.T @ U`
- [x] implement unitest
- [x] perform benchmark against main

--------------

P.S. @mathurinm does this count as a citation :smile:

