### PR TITLE
CLN Consistent namings across solvers

### DIFF
--- a/skglm/solvers/cd_solver.py
+++ b/skglm/solvers/cd_solver.py
@@ -323,14 +323,14 @@ def cd_solver(
                 p_obj = datafit.value(y, w[ws], Xw) + penalty.value(w)
 
                 if is_sparse:
-                    grad = construct_grad_sparse(
+                    grad_ws = construct_grad_sparse(
                         X.data, X.indptr, X.indices, y, w, Xw, datafit, ws)
                 else:
-                    grad = construct_grad(X, y, w, Xw, datafit, ws)
+                    grad_ws = construct_grad(X, y, w, Xw, datafit, ws)
                 if ws_strategy == "subdiff":
-                    opt_ws = penalty.subdiff_distance(w, grad, ws)
+                    opt_ws = penalty.subdiff_distance(w, grad_ws, ws)
                 elif ws_strategy == "fixpoint":
-                    opt_ws = dist_fix_point(w, grad, datafit, penalty, ws)
+                    opt_ws = dist_fix_point(w, grad_ws, datafit, penalty, ws)
 
                 stop_crit_in = np.max(opt_ws)
                 if max(verbose - 1, 0):
@@ -349,7 +349,7 @@ def cd_solver(
 
 
 @njit
-def _cd_epoch(X, y, w, Xw, datafit, penalty, feats):
+def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
     """Run an epoch of coordinate descent in place.
 
     Parameters

--- a/skglm/solvers/cd_solver.py
+++ b/skglm/solvers/cd_solver.py
@@ -372,7 +372,7 @@ def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
     penalty : Penalty
         Penalty.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The range of features.
     """
     lc = datafit.lipschitz
@@ -417,7 +417,7 @@ def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, ws
     penalty : Penalty
         Penalty.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
     """
     lc = datafit.lipschitz

--- a/skglm/solvers/cd_solver.py
+++ b/skglm/solvers/cd_solver.py
@@ -460,7 +460,7 @@ def construct_grad_sparse(data, indptr, indices, y, w, Xw, datafit, ws):
 
 
 @njit
-def _cd_epoch(X, y, w, Xw, datafit, penalty, feats):
+def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
     """Run an epoch of coordinate descent in place.
 
     Parameters
@@ -483,11 +483,11 @@ def _cd_epoch(X, y, w, Xw, datafit, penalty, feats):
     penalty : Penalty
         Penalty.
 
-    feats : array, shape (n_features,)
+    ws : array, shape (n_features,)
         The range of features.
     """
     lc = datafit.lipschitz
-    for j in feats:
+    for j in ws:
         stepsize = 1/lc[j] if lc[j] != 0 else 1000
         Xj = X[:, j]
         old_w_j = w[j]
@@ -499,7 +499,7 @@ def _cd_epoch(X, y, w, Xw, datafit, penalty, feats):
 
 
 @njit
-def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, feats):
+def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, ws):
     """Run an epoch of coordinate descent in place for a sparse CSC array.
 
     Parameters
@@ -528,11 +528,11 @@ def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, fe
     penalty : Penalty
         Penalty.
 
-    feats : array, shape (n_features,)
-        The range of features.
+    ws : array, shape (n_features,)
+        The working set.
     """
     lc = datafit.lipschitz
-    for j in feats:
+    for j in ws:
         stepsize = 1/lc[j] if lc[j] != 0 else 1000
 
         old_w_j = w[j]

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -20,7 +20,7 @@ def dist_fix_point(w, grad_ws, datafit, penalty, ws):
     penalty: instance of BasePenalty
         Penalty.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
 
     Returns
@@ -58,7 +58,7 @@ def construct_grad(X, y, w, Xw, datafit, ws):
     datafit : Datafit
         Datafit.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
 
     Returns
@@ -99,7 +99,7 @@ def construct_grad_sparse(data, indptr, indices, y, w, Xw, datafit, ws):
     datafit : Datafit
         Datafit.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
 
     Returns

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -3,7 +3,7 @@ from numba import njit
 
 
 @njit
-def dist_fix_point(w, grad, datafit, penalty, ws):
+def dist_fix_point(w, grad_ws, datafit, penalty, ws):
     """Compute the violation of the fixed point iterate scheme.
 
     Parameters
@@ -11,8 +11,8 @@ def dist_fix_point(w, grad, datafit, penalty, ws):
     w : array, shape (n_features,)
         Coefficient vector.
 
-    grad : array, shape (n_features,)
-        Gradient.
+    grad_ws : array, shape (ws_size,)
+        Gradient restricted to the working set.
 
     datafit: instance of BaseDatafit
         Datafit.
@@ -33,7 +33,7 @@ def dist_fix_point(w, grad, datafit, penalty, ws):
         lcj = datafit.lipschitz[j]
         if lcj != 0:
             dist_fix_point[idx] = np.abs(
-                w[j] - penalty.prox_1d(w[j] - grad[idx] / lcj, 1. / lcj, j))
+                w[j] - penalty.prox_1d(w[j] - grad_ws[idx] / lcj, 1. / lcj, j))
     return dist_fix_point
 
 

--- a/skglm/solvers/group_bcd_solver.py
+++ b/skglm/solvers/group_bcd_solver.py
@@ -106,10 +106,8 @@ def bcd_solver(X, y, datafit, penalty, w_init=None, p0=10,
                 stop_crit_in = np.max(opt_in)
 
                 if max(verbose - 1, 0):
-                    print(
-                        f"Epoch {epoch+1}: {p_obj:.10f} "
-                        f"obj. variation: {stop_crit_in:.2e}"
-                    )
+                    print(f"Epoch {epoch + 1}, objective {p_obj:.10f}, "
+                          f"stopping crit {stop_crit_in:.2e}")
 
                 if stop_crit_in <= 0.3 * stop_crit:
                     break
@@ -131,9 +129,7 @@ def _bcd_epoch(X, y, w, Xw, datafit, penalty, ws):
         grad_g = datafit.gradient_g(X, y, w, Xw, g)
 
         w[grp_g_indices] = penalty.prox_1group(
-            old_w_g - grad_g / lipschitz_g,
-            1 / lipschitz_g, g
-        )
+            old_w_g - grad_g / lipschitz_g, 1 / lipschitz_g, g)
 
         for idx, j in enumerate(grp_g_indices):
             if old_w_g[idx] != w[j]:

--- a/skglm/solvers/group_bcd_solver.py
+++ b/skglm/solvers/group_bcd_solver.py
@@ -106,8 +106,10 @@ def bcd_solver(X, y, datafit, penalty, w_init=None, p0=10,
                 stop_crit_in = np.max(opt_in)
 
                 if max(verbose - 1, 0):
-                    print(f"Epoch {epoch + 1}, objective {p_obj:.10f}, "
-                          f"stopping crit {stop_crit_in:.2e}")
+                    print(
+                        f"Epoch {epoch + 1}, objective {p_obj:.10f}, "
+                        f"stopping crit {stop_crit_in:.2e}"
+                    )
 
                 if stop_crit_in <= 0.3 * stop_crit:
                     break
@@ -129,7 +131,9 @@ def _bcd_epoch(X, y, w, Xw, datafit, penalty, ws):
         grad_g = datafit.gradient_g(X, y, w, Xw, g)
 
         w[grp_g_indices] = penalty.prox_1group(
-            old_w_g - grad_g / lipschitz_g, 1 / lipschitz_g, g)
+            old_w_g - grad_g / lipschitz_g,
+            1 / lipschitz_g, g
+        )
 
         for idx, j in enumerate(grp_g_indices):
             if old_w_g[idx] != w[j]:

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -329,7 +329,7 @@ def dist_fix_point(W, grad_ws, datafit, penalty, ws):
     penalty: instance of BasePenalty
         Penalty.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
 
     Returns
@@ -367,7 +367,7 @@ def construct_grad(X, Y, W, XW, datafit, ws):
     datafit : instance of BaseMultiTaskDatafit
         Datafit.
 
-    ws : array, shape (n_features,)
+    ws : array, shape (ws_size,)
         The working set.
 
     Returns

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -423,7 +423,7 @@ def construct_grad_sparse(data, indptr, indices, Y, XW, datafit, ws):
 
 
 @njit
-def _bcd_epoch(X, Y, W, XW, datafit, penalty, feats):
+def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place.
 
     Parameters
@@ -446,12 +446,12 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, feats):
     penalty : instance of BasePenalty
         Penalty.
 
-    feats : array, shape (ws_size,)
-        Features to be updated.
+    ws : array, shape (ws_size,)
+        The working set.
     """
     lc = datafit.lipschitz
     n_tasks = Y.shape[1]
-    for j in feats:
+    for j in ws:
         if lc[j] == 0.:
             continue
         Xj = X[:, j]
@@ -467,7 +467,7 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, feats):
 
 
 @njit
-def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, datafit, penalty, feats):
+def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place for a sparse CSC array.
 
     Parameters
@@ -496,11 +496,11 @@ def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, datafit, penalty, f
     penalty : instance of BasePenalty
         Penalty.
 
-    feats : array, shape (ws_size,)
+    ws : array, shape (ws_size,)
         Features to be updated.
     """
     lc = datafit.lipschitz
-    for j in feats:
+    for j in ws:
         if lc[j] == 0.:
             continue
         old_W_j = W[j, :].copy()


### PR DESCRIPTION
The goal of this PR is to harmonize the variable namings and verbose outputs across solvers.

- [x] Closes #30 
- [x] Change `feats` into `ws` in private function for clarity purposes
- [x] Consistent verbose outputs in `group_bcd_solver`