### PR TITLE
[WIP] Investigate low running time of MultiTask Lasso 

### DIFF
--- a/examples/compare_time_mtl.py
+++ b/examples/compare_time_mtl.py
@@ -1,0 +1,95 @@
+# Authors: Quentin Bertrand
+#          Pierre-Antoine Bannier
+"""
+=============================================
+Timing comparison with scikit-learn for MultiTask Lasso
+=============================================
+Compare time to solve medium scale MultiTask Lasso problems with scikit-learn.
+"""
+
+
+import time
+import warnings
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+from libsvmdata import fetch_libsvm
+
+from skglm.utils import make_correlated_data
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.linear_model import MultiTaskLasso as MultiTaskLasso_sklearn
+
+from skglm import MultiTaskLasso
+
+warnings.filterwarnings('ignore', category=ConvergenceWarning)
+
+
+def compute_obj(X, Y, W, alpha, l1_ratio=1):
+    loss = norm(Y - X @ W) ** 2 / (2 * Y.shape[0])
+    penalty = (alpha * l1_ratio * np.sum(norm(W, axis=1))
+               + 0.5 * alpha * (1 - l1_ratio) * (W ** 2).sum())
+    return loss + penalty
+
+n_features = 1000
+n_samples = 1000
+n_tasks = 10
+X, Y, W_true = make_correlated_data(
+    n_samples=n_samples, n_features=n_features, n_tasks=n_tasks,
+    random_state=0)
+
+
+alpha = np.max(norm(X.T @ Y, ord=2, axis=1)) / Y.shape[0] / 10
+
+dict_sklearn = {}
+dict_sklearn["lasso"] = MultiTaskLasso_sklearn(
+    alpha=alpha, fit_intercept=False, tol=1e-12)
+
+dict_ours = {}
+dict_ours["lasso"] = MultiTaskLasso(
+    alpha=alpha, fit_intercept=False, tol=1e-12, verbose=1)
+
+models = ["lasso"]
+
+fig, axarr = plt.subplots(2, 1, constrained_layout=True)
+
+for ax, model, l1_ratio in zip(axarr, models, [1, 0.5]):
+    pobj_dict = {}
+    pobj_dict["sklearn"] = list()
+    pobj_dict["us"] = list()
+
+    time_dict = {}
+    time_dict["sklearn"] = list()
+    time_dict["us"] = list()
+
+    # Remove compilation time
+    dict_ours[model].max_iter = 10_000
+    w_star = dict_ours[model].fit(X, Y).coef_.T
+    pobj_star = compute_obj(X, Y, w_star, alpha, l1_ratio)
+    for n_iter_sklearn in np.unique(np.geomspace(1, 50, num=15).astype(int)):
+        dict_sklearn[model].max_iter = n_iter_sklearn
+
+        t_start = time.time()
+        w_sklearn = dict_sklearn[model].fit(X, Y).coef_.T
+        time_dict["sklearn"].append(time.time() - t_start)
+        pobj_dict["sklearn"].append(compute_obj(
+            X, Y, w_sklearn, alpha, l1_ratio))
+
+    for n_iter_us in range(1, 30):
+        dict_ours[model].max_iter = n_iter_us
+        t_start = time.time()
+        w = dict_ours[model].fit(X, Y).coef_.T
+        time_dict["us"].append(time.time() - t_start)
+        pobj_dict["us"].append(compute_obj(X, Y, w, alpha, l1_ratio))
+
+    ax.semilogy(
+        time_dict["sklearn"], pobj_dict["sklearn"] - pobj_star, label='sklearn')
+    ax.semilogy(
+        time_dict["us"], pobj_dict["us"] - pobj_star, label='skglm')
+
+    # ax.set_ylim((1e-10, 1))
+    ax.set_title(model)
+    ax.legend()
+    ax.set_ylabel("Objective suboptimality")
+
+axarr[1].set_xlabel("Time (s)")
+plt.show(block=False)

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -23,11 +23,18 @@ class L2_1(BasePenalty):
 
     def value(self, W):
         """Compute the L2/1 penalty value."""
-        return self.alpha * np.sqrt(np.sum(W ** 2, axis=1)).sum()
+        val = 0
+        n_features = W.shape[0]
+        for j in range(n_features):
+            val += norm(W[j, :])
+        return self.alpha * val
+        # return self.alpha * (np.sum(W ** 2, axis=1) ** 0.5).sum()
+        # return self.alpha * np.sqrt(np.sum(W ** 2, axis=1)).sum()
 
     def prox_1feat(self, value, stepsize, j):
         """Compute proximal operator of the L2/1 penalty (block soft thresholding)."""
-        return BST(value, self.alpha * stepsize)
+        BST(value, self.alpha * stepsize)
+        # return BST(Wj, value, self.alpha * stepsize)
 
     def subdiff_distance(self, W, grad, ws):
         """Compute distance of negative gradient to the subdifferential at W."""

--- a/skglm/utils.py
+++ b/skglm/utils.py
@@ -23,13 +23,13 @@ def ST_vec(x, u):
 
 
 @njit
-def BST(x, u):
+def BST(arg_prox, u):
     """Block soft-thresholding of vector x at level u."""
-    norm_x = norm(x)
+    norm_x = norm(arg_prox)
     if norm_x < u:
-        return np.zeros_like(x)
+        arg_prox.fill(0.)
     else:
-        return (1 - u / norm_x) * x
+        arg_prox *= (1 - u / norm_x)
 
 
 @njit


### PR DESCRIPTION
In some cases our MultiTask Lasso has some slow cases compared to sklearn.
The goal of this PR is to investigate some suspicious low running time for the MultiTask Lasso. 

With @PABannier:
- [x]  We added an example to compare and profile the MultiTask Lasso
- [x] We manage to remove the numba warning for the MTL  
- [x] We found out that applying the prox was the most costly operation for 1 epoch, up to 50 % of the time of 1 epoch. The prox operation was more costly than accessing the gradients. As in MNE, using in place operation for the update of the vector `W[j, :]`, we managed to decrease the computing time of the proximal operator computation.

Now, the (rank one) update of the residuals seems to be one of the main bottleneck of the `_bcd_epoch` function. We cannot use dgemm rountines as in MNE because numba does not support them. 