### PR TITLE
NOMRG Evaluating space allocation in BCD solver

### DIFF
--- a/profile_mtl.py
+++ b/profile_mtl.py
@@ -4,7 +4,7 @@ from skglm.estimators import MultiTaskLasso
 
 from skglm.datafits import QuadraticMultiTask
 from skglm.penalties import L2_1
-from skglm.solvers.multitask_bcd_solver import bcd_solver 
+from skglm.solvers.multitask_bcd_solver import bcd_solver
 
 
 n_samples, n_features, n_tasks = 30, 100, 10
@@ -44,3 +44,4 @@ pen = L2_1(alpha=alpha)
 W = np.zeros((n_features, n_tasks))
 XW = np.zeros((n_samples, n_tasks))
 bcd_solver(X, Y, quad, pen, W, XW, max_iter=3, use_acc=False)
+profile(bcd_solver)(X, Y, quad, pen, W, XW, max_iter=3, use_acc=False)

--- a/profile_mtl.py
+++ b/profile_mtl.py
@@ -1,0 +1,46 @@
+import numpy as np
+import time
+from skglm.estimators import MultiTaskLasso
+
+from skglm.datafits import QuadraticMultiTask
+from skglm.penalties import L2_1
+from skglm.solvers.multitask_bcd_solver import bcd_solver 
+
+
+n_samples, n_features, n_tasks = 30, 100, 10
+
+X = np.random.normal(0, 1, (n_samples, n_features))
+Y = np.random.normal(0, 1, (n_samples, n_tasks))
+alpha_max = np.max(np.linalg.norm(X.T @ Y, ord=2, axis=1)) / n_samples
+alpha = alpha_max / 10
+
+# compil:
+clf = MultiTaskLasso(alpha=alpha, max_iter=1, fit_intercept=False, verbose=1).fit(X, Y)
+t0 = time.time()
+clf = MultiTaskLasso(alpha=alpha, max_iter=3, fit_intercept=False, verbose=1).fit(X, Y)
+t1 = time.time()
+print(f"Fit with max_iter=3: {(t1 -t0):.2f} s")
+
+print("#" * 80)
+quad = QuadraticMultiTask()
+quad.initialize(X, Y)
+t0 = time.time()
+quad.initialize(X, Y)
+t1 = time.time()
+print(f"quad init aka ~2x KKT/Grad computation: {(t1 -t0):.2f} s")
+print("#" * 80)
+
+
+pen = L2_1(alpha=alpha)
+
+# W = np.zeros((n_features, n_tasks))
+# XW = np.zeros((n_samples, n_tasks))
+# t0 = time.time()
+# bcd_solver(X, Y, quad, pen, W, XW, max_iter=3, verbose=2, use_acc=False)
+# t1 = time.time()
+# print(f"solver call: {t1 - t0:.2f} s")
+
+
+W = np.zeros((n_features, n_tasks))
+XW = np.zeros((n_samples, n_tasks))
+bcd_solver(X, Y, quad, pen, W, XW, max_iter=3, use_acc=False)

--- a/skglm/datafits/multi_task.py
+++ b/skglm/datafits/multi_task.py
@@ -1,14 +1,18 @@
 import numpy as np
 from numpy.linalg import norm
-from numba import float64
+from numba import float64, types, typed
 from numba.experimental import jitclass
 
 from skglm.datafits.base import BaseMultitaskDatafit
 
 
+float_vector = types.Array(dtype=float64, ndim=1, layout="C")
+
+
 spec_quadratic = [
     ('XtY', float64[:, :]),
     ('lipschitz', float64[:]),
+    ('list_X_j_c', types.ListType(float_vector))
 ]
 
 
@@ -41,6 +45,10 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
         for j in range(n_features):
             self.lipschitz[j] = norm(X[:, j]) ** 2 / n_samples
 
+        self.list_X_j_c = typed.List.empty_list(float_vector)
+        for j in range(n_features):
+            self.list_X_j_c.append(np.ascontiguousarray(X[:, j]))
+
     def initialize_sparse(self, X_data, X_indptr, X_indices, Y):
         """Pre-computations before fitting on X and Y, when X is sparse."""
         n_samples, n_tasks = Y.shape
@@ -66,7 +74,7 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
     def gradient_j(self, X, Y, W, XW, j):
         """Gradient with respect to j-th coordinate of W."""
         n_samples = X.shape[0]
-        return (X[:, j:j+1].T @ XW - self.XtY[j, :]) / n_samples
+        return (self.list_X_j_c[j].T @ XW - self.XtY[j, :]) / n_samples
 
     def gradient_j_sparse(self, X_data, X_indptr, X_indices, Y, XW, j):
         """Gradient with respect to j-th coordinate of W when X is sparse."""

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -27,7 +27,7 @@ class L2_1(BasePenalty):
 
     def prox_1feat(self, value, stepsize, j):
         """Compute proximal operator of the L2/1 penalty (block soft thresholding)."""
-        return BST(value, self.alpha * stepsize)
+        BST(value, self.alpha * stepsize)
 
     def subdiff_distance(self, W, grad, ws):
         """Compute distance of negative gradient to the subdifferential at W."""

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -422,7 +422,8 @@ def construct_grad_sparse(data, indptr, indices, Y, XW, datafit, ws):
     return grad
 
 
-@njit
+# @njit
+@profile
 def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place.
 
@@ -456,9 +457,9 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
             continue
         Xj = X[:, j]
         old_W_j = W[j, :].copy()  # copy is very important here
-        W[j:j+1, :] = penalty.prox_1feat(
-            W[j:j+1, :] - datafit.gradient_j(X, Y, W, XW, j) / lc[j],
-            1 / lc[j], j)
+        # arg_prox = W[j, :] - datafit.gradient_j(X, Y, W, XW, j) / lc[j]
+        W[j, :] = W[j, :] - datafit.gradient_j(X, Y, W, XW, j) / lc[j]
+        penalty.prox_1feat(W[j], 1 / lc[j], j)
         if not np.all(W[j, :] == old_W_j):
             for k in range(n_tasks):
                 tmp = W[j, k] - old_W_j[k]

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -422,8 +422,7 @@ def construct_grad_sparse(data, indptr, indices, Y, XW, datafit, ws):
     return grad
 
 
-# @njit
-@profile
+@njit
 def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place.
 

--- a/skglm/utils.py
+++ b/skglm/utils.py
@@ -22,15 +22,22 @@ def ST_vec(x, u):
     return np.sign(x) * np.maximum(0., np.abs(x) - u)
 
 
-@njit
-def BST(x, u):
-    """Block soft-thresholding of vector x at level u."""
-    norm_x = norm(x)
-    if norm_x < u:
-        return np.zeros_like(x)
-    else:
-        return (1 - u / norm_x) * x
+# @njit
+# def BST(x, u):
+#     """Block soft-thresholding of vector x at level u."""
+#     norm_x = norm(x)
+#     if norm_x < u:
+#         return np.zeros_like(x)
+#     else:
+#         return (1 - u / norm_x) * x
 
+@njit
+def BST(arg_prox, u):
+    norm_arg_prox = norm(arg_prox)
+    if norm_arg_prox < u:
+        arg_prox.fill(0.)
+    else:
+        arg_prox *= (1 - u / norm_arg_prox)
 
 @njit
 def box_proj(x, low, up):


### PR DESCRIPTION
In the wake of #39 , this PR profiles the memory allocated by the multi-task BCD solver. It appears that arrays are copied when the prox is evaluated, which makes the procedure very slow when `n_samples` grow.

This PR consists in quantifying the gain in speed due to modifying arrays in place.