### PR TITLE
[READY] ENH - Extend ``AndersonAcceleration`` class to handle matrix iterates

### DIFF
--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -5,6 +5,8 @@ from numba import njit
 from numpy.linalg import norm
 from sklearn.utils import check_array
 
+from skglm.utils import AndersonAcceleration
+
 
 def bcd_solver_path(
         X, Y, datafit, penalty, alphas=None,
@@ -211,6 +213,7 @@ def bcd_solver(
     obj_out = []
     all_feats = np.arange(n_features)
     stop_crit = np.inf  # initialize for case n_iter=0
+    accelerator = AndersonAcceleration(K=5)
 
     is_sparse = sparse.issparse(X)
     for t in range(max_iter):
@@ -238,10 +241,6 @@ def bcd_solver(
         ws = np.argpartition(opt, -ws_size)[-ws_size:]
         # is equivalent to ws = np.argsort(kkt)[-ws_size:]
 
-        if use_acc:
-            last_K_w = np.zeros([K + 1, ws_size * n_tasks])
-            U = np.zeros([K, ws_size * n_tasks])
-
         if verbose:
             print(f'Iteration {t + 1}, {ws_size} feats in subpb.')
 
@@ -254,36 +253,18 @@ def bcd_solver(
                     ws)
             else:
                 _bcd_epoch(X, Y, W, XW, datafit, penalty, ws)
-            if use_acc:
-                last_K_w[epoch % (K + 1)] = W[ws, :].ravel()
 
-                # 3) do Anderson acceleration on smaller problem
-                if epoch % (K + 1) == K:
-                    for k in range(K):
-                        U[k] = last_K_w[k + 1] - last_K_w[k]
-                    C = np.dot(U, U.T)
+            W_acc, XW_acc, is_extrapolated = accelerator.extrapolate(W, XW)
 
-                    try:
-                        z = np.linalg.solve(C, np.ones(K))
-                        c = z / z.sum()
-                        W_acc = np.zeros((n_features, n_tasks))
-                        W_acc[ws, :] = np.sum(
-                            last_K_w[:-1] * c[:, None], axis=0).reshape(
-                                (ws_size, n_tasks))
-                        p_obj = datafit.value(Y, W, XW) + penalty.value(W)
-                        Xw_acc = X[:, ws] @ W_acc[ws]
-                        p_obj_acc = datafit.value(
-                            Y, W_acc, Xw_acc) + penalty.value(W_acc)
-                        if p_obj_acc < p_obj:
-                            W[:] = W_acc
-                            XW[:] = Xw_acc
-                    except np.linalg.LinAlgError:
-                        if max(verbose - 1, 0):
-                            print("----------Linalg error")
+            if is_extrapolated:  # avoid computing p_obj for un-extrapolated w, Xw
+                p_obj = datafit.value(Y, W, XW) + penalty.value(W)
+                p_obj_acc = datafit.value(Y, W_acc, XW_acc) + penalty.value(W_acc)
+
+                if p_obj_acc < p_obj:
+                    W[:], XW[:] = W_acc, XW_acc
+                    p_obj = p_obj_acc
 
             if epoch > 0 and epoch % 10 == 0:
-                p_obj = datafit.value(Y, W[ws, :], XW) + penalty.value(W)
-
                 if is_sparse:
                     grad_ws = construct_grad_sparse(
                         X.data, X.indptr, X.indices, Y, XW, datafit, ws)
@@ -297,6 +278,7 @@ def bcd_solver(
 
                 stop_crit_in = np.max(opt_ws)
                 if max(verbose - 1, 0):
+                    p_obj = datafit.value(Y, W[ws, :], XW) + penalty.value(W)
                     print(f"Epoch {epoch + 1}, objective {p_obj:.10f}, "
                           f"stopping crit {stop_crit_in:.2e}")
                 if ws_size == n_features:
@@ -307,6 +289,7 @@ def bcd_solver(
                         if max(verbose - 1, 0):
                             print("Early exit")
                         break
+        p_obj = datafit.value(Y, W, XW) + penalty.value(W)
         obj_out.append(p_obj)
     return W, np.array(obj_out), stop_crit
 

--- a/skglm/solvers/multitask_bcd_solver.py
+++ b/skglm/solvers/multitask_bcd_solver.py
@@ -5,8 +5,6 @@ from numba import njit
 from numpy.linalg import norm
 from sklearn.utils import check_array
 
-from skglm.utils import AndersonAcceleration
-
 
 def bcd_solver_path(
         X, Y, datafit, penalty, alphas=None,
@@ -213,7 +211,6 @@ def bcd_solver(
     obj_out = []
     all_feats = np.arange(n_features)
     stop_crit = np.inf  # initialize for case n_iter=0
-    accelerator = AndersonAcceleration(K=5)
 
     is_sparse = sparse.issparse(X)
     for t in range(max_iter):
@@ -241,6 +238,10 @@ def bcd_solver(
         ws = np.argpartition(opt, -ws_size)[-ws_size:]
         # is equivalent to ws = np.argsort(kkt)[-ws_size:]
 
+        if use_acc:
+            last_K_w = np.zeros([K + 1, ws_size * n_tasks])
+            U = np.zeros([K, ws_size * n_tasks])
+
         if verbose:
             print(f'Iteration {t + 1}, {ws_size} feats in subpb.')
 
@@ -253,18 +254,36 @@ def bcd_solver(
                     ws)
             else:
                 _bcd_epoch(X, Y, W, XW, datafit, penalty, ws)
+            if use_acc:
+                last_K_w[epoch % (K + 1)] = W[ws, :].ravel()
 
-            W_acc, XW_acc, is_extrapolated = accelerator.extrapolate(W, XW)
+                # 3) do Anderson acceleration on smaller problem
+                if epoch % (K + 1) == K:
+                    for k in range(K):
+                        U[k] = last_K_w[k + 1] - last_K_w[k]
+                    C = np.dot(U, U.T)
 
-            if is_extrapolated:  # avoid computing p_obj for un-extrapolated w, Xw
-                p_obj = datafit.value(Y, W, XW) + penalty.value(W)
-                p_obj_acc = datafit.value(Y, W_acc, XW_acc) + penalty.value(W_acc)
-
-                if p_obj_acc < p_obj:
-                    W[:], XW[:] = W_acc, XW_acc
-                    p_obj = p_obj_acc
+                    try:
+                        z = np.linalg.solve(C, np.ones(K))
+                        c = z / z.sum()
+                        W_acc = np.zeros((n_features, n_tasks))
+                        W_acc[ws, :] = np.sum(
+                            last_K_w[:-1] * c[:, None], axis=0).reshape(
+                                (ws_size, n_tasks))
+                        p_obj = datafit.value(Y, W, XW) + penalty.value(W)
+                        Xw_acc = X[:, ws] @ W_acc[ws]
+                        p_obj_acc = datafit.value(
+                            Y, W_acc, Xw_acc) + penalty.value(W_acc)
+                        if p_obj_acc < p_obj:
+                            W[:] = W_acc
+                            XW[:] = Xw_acc
+                    except np.linalg.LinAlgError:
+                        if max(verbose - 1, 0):
+                            print("----------Linalg error")
 
             if epoch > 0 and epoch % 10 == 0:
+                p_obj = datafit.value(Y, W[ws, :], XW) + penalty.value(W)
+
                 if is_sparse:
                     grad_ws = construct_grad_sparse(
                         X.data, X.indptr, X.indices, Y, XW, datafit, ws)
@@ -278,7 +297,6 @@ def bcd_solver(
 
                 stop_crit_in = np.max(opt_ws)
                 if max(verbose - 1, 0):
-                    p_obj = datafit.value(Y, W[ws, :], XW) + penalty.value(W)
                     print(f"Epoch {epoch + 1}, objective {p_obj:.10f}, "
                           f"stopping crit {stop_crit_in:.2e}")
                 if ws_size == n_features:
@@ -289,7 +307,6 @@ def bcd_solver(
                         if max(verbose - 1, 0):
                             print("Early exit")
                         break
-        p_obj = datafit.value(Y, W, XW) + penalty.value(W)
         obj_out.append(p_obj)
     return W, np.array(obj_out), stop_crit
 

--- a/skglm/tests/test_group.py
+++ b/skglm/tests/test_group.py
@@ -122,19 +122,20 @@ def test_vs_celer_grouplasso(n_groups, n_features, shuffle):
     np.testing.assert_allclose(model.coef_, w, atol=1e-5)
 
 
-def test_anderson_acceleration():
+@pytest.mark.parametrize("n_features, n_tasks", [(2, 1), (2, 5)])
+def test_anderson_acceleration(n_features, n_tasks):
     # VAR: w = rho * w + 1 with |rho| < 1
     # converges to w_star = 1 / (1 - rho)
     max_iter, tol = 1000, 1e-9
-    n_features = 2
-    rho = np.array([0.5, 0.8])
+    np.random.seed(0)
+    rho = np.random.rand(n_features, n_tasks)
     w_star = 1 / (1 - rho)
     X = np.diag([2, 5])
 
     # with acceleration
     acc = AndersonAcceleration(K=5)
     n_iter_acc = 0
-    w = np.ones(n_features)
+    w = np.ones((n_features, n_tasks))
     Xw = X @ w
     for i in range(max_iter):
         w, Xw, _ = acc.extrapolate(w, Xw)
@@ -147,7 +148,7 @@ def test_anderson_acceleration():
 
     # without acceleration
     n_iter = 0
-    w = np.ones(n_features)
+    w = np.ones((n_features, n_tasks))
     for i in range(max_iter):
         w = rho * w + 1
 
@@ -158,8 +159,7 @@ def test_anderson_acceleration():
     np.testing.assert_allclose(w, w_star)
     np.testing.assert_allclose(Xw, X @ w_star)
 
-    np.testing.assert_array_equal(n_iter_acc, 13)
-    np.testing.assert_array_equal(n_iter, 99)
+    np.testing.assert_array_less(n_iter_acc, n_iter)
 
 
 if __name__ == '__main__':

--- a/skglm/utils.py
+++ b/skglm/utils.py
@@ -342,8 +342,9 @@ class AndersonAcceleration:
 
         # compute extrapolation coefs
         try:
-            U_flatten = U if w.ndim == 1 else U.reshape(-1, self.K)
-            inv_UTU_ones = np.linalg.solve(U_flatten.T @ U_flatten, np.ones(self.K))
+            # else close equivalent to U.reshape(-1, K).T @ U.reshape(-1, K)
+            UTU = U.T @ U if w.ndim == 1 else np.tensordot(U, U, axes=[(0, 1), (0, 1)])
+            inv_UTU_ones = np.linalg.solve(UTU, np.ones(self.K))
         except np.linalg.LinAlgError:
             return w, Xw, False
         finally:

--- a/skglm/utils.py
+++ b/skglm/utils.py
@@ -352,4 +352,4 @@ class AndersonAcceleration:
         # extrapolate
         C = inv_UTU_ones / np.sum(inv_UTU_ones)
         # floating point errors may cause w and Xw to disagree
-        return (self.arr_w_[..., 1:] @ C, self.arr_Xw_[..., 1:] @ C, True)
+        return self.arr_w_[..., 1:] @ C, self.arr_Xw_[..., 1:] @ C, True


### PR DESCRIPTION
This tackles check box 1 in https://github.com/scikit-learn-contrib/skglm/pull/33#issuecomment-1187319921.

It proceeds as follows:

- [x] extend AA to handle ``w``, ``Xw`` matrices
  (for multi-task lasso)
- [x] add unitest for the matrix case
- [x] refactor MLT solver to integrate AA class
- [x] benchmark against main to ensure no performance loss

-----------
[benchmark results](https://badr-moufad.github.io/share-benchmarks/mlt_solver/benchmark_aa_multi_benchopt_run_2022-07-27_23h54m58.html)