### PR TITLE
[READY] More idiomatic imports in `__init__` files

### DIFF
--- a/skglm/datafits/__init__.py
+++ b/skglm/datafits/__init__.py
@@ -1,7 +1,12 @@
-from .base import BaseDatafit, BaseMultitaskDatafit  # noqa F401
+from .base import BaseDatafit, BaseMultitaskDatafit
+from .single_task import Quadratic, QuadraticSVC, Logistic, Huber
+from .multi_task import QuadraticMultiTask
+from .group import QuadraticGroup
 
-from .single_task import Quadratic, QuadraticSVC, Logistic, Huber  # noqa F401
 
-from .multi_task import QuadraticMultiTask  # noqa F401
-
-from .group import QuadraticGroup  # noqa F401
+__all__ = [
+    BaseDatafit, BaseMultitaskDatafit,
+    Quadratic, QuadraticSVC, Logistic, Huber,
+    QuadraticMultiTask,
+    QuadraticGroup
+]

--- a/skglm/penalties/__init__.py
+++ b/skglm/penalties/__init__.py
@@ -1,9 +1,14 @@
-from .base import BasePenalty  # noqa F401
-
-from .separable import (  # noqa F401
-    L1_plus_L2, L0_5, L1, L2_3, MCPenalty, SCAD, WeightedL1, IndicatorBox, BasePenalty
+from .base import BasePenalty
+from .separable import (
+    L1_plus_L2, L0_5, L1, L2_3, MCPenalty, SCAD, WeightedL1, IndicatorBox
 )
-
-from .block_separable import ( # noqa F401
+from .block_separable import (
     L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2
 )
+
+
+__all__ = [
+    BasePenalty,
+    L1_plus_L2, L0_5, L1, L2_3, MCPenalty, SCAD, WeightedL1, IndicatorBox,
+    L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2
+]


### PR DESCRIPTION
This PR changes the imports in the `__init__` files of the Datafit and Penalty submodules.
As suggested by @mathurinm , instead of appending `noqa F401` at the end of every line, imported objects can be made available in `__all__`.
