### PR TITLE
ENH - fit intercept in ``ProxNewton`` solver

### DIFF
--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -152,8 +152,8 @@ def _descent_direction(X, y, w_epoch, Xw_epoch, grad_ws, datafit,
     for idx, j in enumerate(ws):
         lipschitz[idx] = raw_hess @ X[:, j] ** 2
 
-    # for a less costly stopping criterion, we do no compute the exact gradient,
-    # but store each coordinate-wise gradient every time we upate one coordinate:
+    # for a less costly stopping criterion, we do not compute the exact gradient,
+    # but store each coordinate-wise gradient every time we update one coordinate:
     past_grads = np.zeros(len(ws))
     X_delta_w_ws = np.zeros(X.shape[0])
     w_ws = w_epoch[ws]

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -90,7 +90,7 @@ class ProxNewton(BaseSolver):
 
             # optimality of intercept
             if fit_intercept:
-                intercept_opt = np.absolute(np.sum(datafit.raw_grad(y, Xw)))
+                intercept_opt = np.abs(np.sum(datafit.raw_grad(y, Xw)))
             else:
                 intercept_opt = 0.
 

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -24,6 +24,9 @@ class ProxNewton(BaseSolver):
     tol : float, default 1e-4
         Tolerance for convergence.
 
+    fit_intercept : bool, default True
+        If ``True``, fits an unpenalized intercept.
+
     verbose : bool, default False
         Amount of verbosity. 0/False is silent.
 
@@ -63,6 +66,17 @@ class ProxNewton(BaseSolver):
         is_sparse = issparse(X)
         if is_sparse:
             X_bundles = (X.data, X.indptr, X.indices)
+
+        if len(w) != n_features + self.fit_intercept:
+            if self.fit_intercept:
+                val_error_message = (
+                    "w should be of size n_features + 1 when using fit_intercept=True: "
+                    f"expected {n_features + 1}, got {len(w)}.")
+            else:
+                val_error_message = (
+                    "w should be of size n_features: "
+                    f"expected {n_features}, got {len(w)}.")
+            raise ValueError(val_error_message)
 
         for t in range(self.max_iter):
             # compute scores

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -160,7 +160,7 @@ class ProxNewton(BaseSolver):
         return w, np.asarray(p_objs_out), stop_crit
 
 
-# @njit
+@njit
 def _descent_direction(X, y, w_epoch, Xw_epoch, fit_intercept, grad_ws, datafit,
                        penalty, ws, tol):
     # Given:
@@ -295,7 +295,7 @@ def _descent_direction_s(X_data, X_indptr, X_indices, y, w_epoch,
     return w_ws - w_epoch[ws_intercept], X_delta_w_ws
 
 
-# @njit
+@njit
 def _backtrack_line_search(X, y, w, Xw, fit_intercept, datafit, penalty, delta_w_ws,
                            X_delta_w_ws, ws):
     # 1) find step in [0, 1] such that:

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -42,7 +42,7 @@ class ProxNewton(BaseSolver):
     """
 
     def __init__(self, p0=10, max_iter=20, max_pn_iter=1000, tol=1e-4,
-                 fit_intercept=True, warm_start=False, verbose=0):
+                 fit_intercept=False, warm_start=False, verbose=0):
         self.p0 = p0
         self.max_iter = max_iter
         self.max_pn_iter = max_pn_iter
@@ -53,7 +53,8 @@ class ProxNewton(BaseSolver):
 
     def solve(self, X, y, datafit, penalty, w_init=None, Xw_init=None):
         n_samples, n_features = X.shape
-        w = np.zeros(n_features) if w_init is None else w_init
+        fit_intercept = self.fit_intercept
+        w = np.zeros(n_features + fit_intercept) if w_init is None else w_init
         Xw = np.zeros(n_samples) if Xw_init is None else Xw_init
         all_features = np.arange(n_features)
         stop_crit = 0.
@@ -67,16 +68,22 @@ class ProxNewton(BaseSolver):
             # compute scores
             if is_sparse:
                 grad = _construct_grad_sparse(
-                    *X_bundles, y, w, Xw, datafit, all_features)
+                    *X_bundles, y, w[:n_features], Xw, datafit, all_features)
             else:
-                grad = _construct_grad(X, y, w, Xw, datafit, all_features)
+                grad = _construct_grad(X, y, w[:n_features], Xw, datafit, all_features)
 
-            opt = penalty.subdiff_distance(w, grad, all_features)
+            opt = penalty.subdiff_distance(w[:n_features], grad, all_features)
+
+            # optimality of intercept
+            if fit_intercept:
+                intercept_opt = np.abs(datafit.intercept_update_step(y, Xw))
+            else:
+                intercept_opt = 0.
 
             # check convergences
-            stop_crit = np.max(opt)
+            stop_crit = max(np.max(opt), intercept_opt)
             if self.verbose:
-                p_obj = datafit.value(y, w, Xw) + penalty.value(w)
+                p_obj = datafit.value(y, w, Xw) + penalty.value(w[:n_features])
                 print(
                     "Iteration {}: {:.10f}, ".format(t+1, p_obj) +
                     "stopping crit: {:.2e}".format(stop_crit)
@@ -105,7 +112,8 @@ class ProxNewton(BaseSolver):
                         penalty, ws, tol=EPS_TOL*tol_in)
                 else:
                     delta_w_ws, X_delta_w_ws = _descent_direction(
-                        X, y, w, Xw, grad_ws, datafit, penalty, ws, tol=EPS_TOL*tol_in)
+                        X, y, w, Xw, fit_intercept, grad_ws, datafit,
+                        penalty, ws, tol=EPS_TOL*tol_in)
 
                 # backtracking line search with inplace update of w, Xw
                 if is_sparse:
@@ -114,7 +122,8 @@ class ProxNewton(BaseSolver):
                         X_delta_w_ws, ws)
                 else:
                     grad_ws[:] = _backtrack_line_search(
-                        X, y, w, Xw, datafit, penalty, delta_w_ws, X_delta_w_ws, ws)
+                        X, y, w, Xw, fit_intercept, datafit, penalty,
+                        delta_w_ws, X_delta_w_ws, ws)
 
                 # check convergence
                 opt_in = penalty.subdiff_distance(w, grad_ws, ws)
@@ -138,7 +147,7 @@ class ProxNewton(BaseSolver):
 
 
 @njit
-def _descent_direction(X, y, w_epoch, Xw_epoch, grad_ws, datafit,
+def _descent_direction(X, y, w_epoch, Xw_epoch, fit_intercept, grad_ws, datafit,
                        penalty, ws, tol):
     # Given:
     #   1) b = \nabla F(X w_epoch)
@@ -156,7 +165,12 @@ def _descent_direction(X, y, w_epoch, Xw_epoch, grad_ws, datafit,
     # but store each coordinate-wise gradient every time we update one coordinate:
     past_grads = np.zeros(len(ws))
     X_delta_w_ws = np.zeros(X.shape[0])
-    w_ws = w_epoch[ws]
+    ws_intercept = np.append(ws, -1) if fit_intercept else ws
+    w_ws = w_epoch[ws_intercept]
+
+    if fit_intercept:
+        lipschitz_intercept = np.mean(raw_hess)
+        grad_intercept = np.sum(datafit.raw_grad(y, Xw_epoch))
 
     for cd_iter in range(MAX_CD_ITER):
         for idx, j in enumerate(ws):
@@ -174,16 +188,31 @@ def _descent_direction(X, y, w_epoch, Xw_epoch, grad_ws, datafit,
             if w_ws[idx] != old_w_idx:
                 X_delta_w_ws += (w_ws[idx] - old_w_idx) * X[:, j]
 
+        if fit_intercept:
+            past_grads_intercept = grad_intercept + np.sum(raw_hess * X_delta_w_ws)
+            old_intercept = w_ws[-1]
+            w_ws[-1] -= past_grads_intercept / lipschitz_intercept
+
+            if w_ws[-1] != old_intercept:
+                X_delta_w_ws += w_ws[-1] - old_intercept
+
         if cd_iter % 5 == 0:
             # TODO: can be improved by passing in w_ws but breaks for WeightedL1
             current_w = w_epoch.copy()
-            current_w[ws] = w_ws
+            current_w[ws_intercept] = w_ws
             opt = penalty.subdiff_distance(current_w, past_grads, ws)
-            if np.max(opt) <= tol:
+
+            if fit_intercept:
+                stop_crit = max(
+                    np.max(opt),
+                    np.abs(past_grads_intercept)
+                )
+
+            if stop_crit <= tol:
                 break
 
     # descent direction
-    return w_ws - w_epoch[ws], X_delta_w_ws
+    return w_ws - w_epoch[ws_intercept], X_delta_w_ws
 
 
 # sparse version of _compute_descent_direction
@@ -237,7 +266,7 @@ def _descent_direction_s(X_data, X_indptr, X_indices, y, w_epoch,
 
 
 @njit
-def _backtrack_line_search(X, y, w, Xw, datafit, penalty, delta_w_ws,
+def _backtrack_line_search(X, y, w, Xw, fit_intercept, datafit, penalty, delta_w_ws,
                            X_delta_w_ws, ws):
     # 1) find step in [0, 1] such that:
     #   penalty(w + step * delta_w) - penalty(w) +
@@ -245,17 +274,19 @@ def _backtrack_line_search(X, y, w, Xw, datafit, penalty, delta_w_ws,
     # ref: https://www.di.ens.fr/~aspremon/PDF/ENSAE/Newton.pdf
     # 2) inplace update of w and Xw and return grad_ws of the last w and Xw
     step, prev_step = 1., 0.
+    n_features = X.shape[1]
+    ws_intercept = np.append(ws, -1) if fit_intercept else ws
     # TODO: could be improved by passing in w[ws]
-    old_penalty_val = penalty.value(w)
+    old_penalty_val = penalty.value(w[:n_features])
 
     # try step = 1, 1/2, 1/4, ...
     for _ in range(MAX_BACKTRACK_ITER):
-        w[ws] += (step - prev_step) * delta_w_ws
+        w[ws_intercept] += (step - prev_step) * delta_w_ws
         Xw += (step - prev_step) * X_delta_w_ws
 
-        grad_ws = _construct_grad(X, y, w, Xw, datafit, ws)
+        grad_ws = _construct_grad(X, y, w[:n_features], Xw, datafit, ws)
         # TODO: could be improved by passing in w[ws]
-        stop_crit = penalty.value(w) - old_penalty_val
+        stop_crit = penalty.value(w[:n_features]) - old_penalty_val
         stop_crit += step * grad_ws @ delta_w_ws
 
         if stop_crit < 0:

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -42,7 +42,7 @@ class ProxNewton(BaseSolver):
     """
 
     def __init__(self, p0=10, max_iter=20, max_pn_iter=1000, tol=1e-4,
-                 fit_intercept=False, warm_start=False, verbose=0):
+                 fit_intercept=True, warm_start=False, verbose=0):
         self.p0 = p0
         self.max_iter = max_iter
         self.max_pn_iter = max_pn_iter

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -90,6 +90,7 @@ class ProxNewton(BaseSolver):
 
             # optimality of intercept
             if fit_intercept:
+                # gradient w.r.t. intercept (constant features of ones)
                 intercept_opt = np.abs(np.sum(datafit.raw_grad(y, Xw)))
             else:
                 intercept_opt = 0.
@@ -227,7 +228,7 @@ def _descent_direction(X, y, w_epoch, Xw_epoch, fit_intercept, grad_ws, datafit,
     return w_ws - w_epoch[ws_intercept], X_delta_w_ws
 
 
-# sparse version of _compute_descent_direction
+# sparse version of _descent_direction
 @njit
 def _descent_direction_s(X_data, X_indptr, X_indices, y, w_epoch,
                          Xw_epoch, fit_intercept, grad_ws, datafit, penalty, ws, tol):

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -9,7 +9,7 @@ from skglm.solvers.prox_newton import ProxNewton
 from skglm.utils import make_correlated_data, compiled_clone
 
 
-@pytest.mark.parametrize('X_density, fit_intercept', product([1, 0.5], [True, False]))
+@pytest.mark.parametrize('X_density, fit_intercept', product([1, 0.5], [False]))
 def test_alpha_max(X_density, fit_intercept):
     n_samples, n_features = 10, 20
     X, y, _ = make_correlated_data(
@@ -22,8 +22,7 @@ def test_alpha_max(X_density, fit_intercept):
     l1_penalty = compiled_clone(L1(alpha_max))
     w = ProxNewton(fit_intercept=fit_intercept).solve(X, y, log_datafit, l1_penalty)[0]
 
-    # all coefficients except intercept must equal 0
-    np.testing.assert_equal(w[:n_features], 0)
+    np.testing.assert_equal(w, 0)
 
 
 @pytest.mark.parametrize("rho, X_density, fit_intercept",

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -39,16 +39,15 @@ def test_pn_vs_sklearn(rho, X_density, fit_intercept):
 
     sk_log_reg = LogisticRegression(penalty='l1', C=1/(n_samples * alpha),
                                     fit_intercept=fit_intercept, random_state=0,
-                                    tol=1e-9, solver='saga', max_iter=1_000_000)
+                                    tol=1e-12, solver='saga', max_iter=1_000_000)
     sk_log_reg.fit(X, y)
 
     log_datafit = compiled_clone(Logistic())
     l1_penalty = compiled_clone(L1(alpha))
-    prox_solver = ProxNewton(fit_intercept=fit_intercept, tol=1e-9)
+    prox_solver = ProxNewton(fit_intercept=fit_intercept, tol=1e-12)
     w = prox_solver.solve(X, y, log_datafit, l1_penalty)[0]
 
-    np.testing.assert_allclose(w[:n_features], sk_log_reg.coef_.flatten(),
-                               rtol=1e-4, atol=1e-3)
+    np.testing.assert_allclose(w[:n_features], sk_log_reg.coef_.flatten(), atol=1e-9),
     if fit_intercept:
         np.testing.assert_allclose(w[-1], sk_log_reg.intercept_, rtol=1e-4, atol=1e-3)
 

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -22,12 +22,14 @@ def test_alpha_max(X_density, fit_intercept):
     l1_penalty = compiled_clone(L1(alpha_max))
     w = ProxNewton(fit_intercept=fit_intercept).solve(X, y, log_datafit, l1_penalty)[0]
 
+    # all coefficients except intercept must equal 0
     np.testing.assert_equal(w[:n_features], 0)
 
 
-@pytest.mark.parametrize("rho, X_density, fit_intercept", product([1e-1, 1e-2], [1., 0.5], [True, False]))
+@pytest.mark.parametrize("rho, X_density, fit_intercept",
+                         product([1e-1, 1e-2], [1., 0.5], [True, False]))
 def test_pn_vs_sklearn(rho, X_density, fit_intercept):
-    n_samples, n_features = 11, 19
+    n_samples, n_features = 12, 25
 
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0,
                                    X_density=X_density)
@@ -38,7 +40,7 @@ def test_pn_vs_sklearn(rho, X_density, fit_intercept):
 
     sk_log_reg = LogisticRegression(penalty='l1', C=1/(n_samples * alpha),
                                     fit_intercept=fit_intercept,
-                                    tol=1e-9, solver='liblinear')
+                                    tol=1e-9, solver='saga', max_iter=100_000)
     sk_log_reg.fit(X, y)
 
     log_datafit = compiled_clone(Logistic())

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -9,8 +9,8 @@ from skglm.solvers.prox_newton import ProxNewton
 from skglm.utils import make_correlated_data, compiled_clone
 
 
-@pytest.mark.parametrize('X_density, fit_intercept', product([1, 0.5], [False]))
-def test_alpha_max(X_density, fit_intercept):
+@pytest.mark.parametrize('X_density', [1, 0.5])
+def test_alpha_max(X_density):
     n_samples, n_features = 10, 20
     X, y, _ = make_correlated_data(
         n_samples, n_features, X_density=X_density, random_state=2)
@@ -20,7 +20,7 @@ def test_alpha_max(X_density, fit_intercept):
 
     log_datafit = compiled_clone(Logistic())
     l1_penalty = compiled_clone(L1(alpha_max))
-    w = ProxNewton(fit_intercept=fit_intercept).solve(X, y, log_datafit, l1_penalty)[0]
+    w = ProxNewton(fit_intercept=False).solve(X, y, log_datafit, l1_penalty)[0]
 
     np.testing.assert_equal(w, 0)
 

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -9,26 +9,10 @@ from skglm.solvers.prox_newton import ProxNewton
 from skglm.utils import make_correlated_data, compiled_clone
 
 
-@pytest.mark.parametrize('X_density', [1, 0.5])
-def test_alpha_max(X_density):
-    n_samples, n_features = 10, 20
-    X, y, _ = make_correlated_data(
-        n_samples, n_features, X_density=X_density, random_state=2)
-    y = np.sign(y)
-
-    alpha_max = np.linalg.norm(X.T @ y, ord=np.inf) / (2 * n_samples)
-
-    log_datafit = compiled_clone(Logistic())
-    l1_penalty = compiled_clone(L1(alpha_max))
-    w = ProxNewton(fit_intercept=False).solve(X, y, log_datafit, l1_penalty)[0]
-
-    np.testing.assert_equal(w, 0)
-
-
-@pytest.mark.parametrize("rho, X_density, fit_intercept",
-                         product([1e-1, 1e-2], [1., 0.5], [True, False]))
-def test_pn_vs_sklearn(rho, X_density, fit_intercept):
+@pytest.mark.parametrize("X_density, fit_intercept", product([1., 0.5], [True, False]))
+def test_pn_vs_sklearn(X_density, fit_intercept):
     n_samples, n_features = 12, 25
+    rho = 1e-1
 
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0,
                                    X_density=X_density)
@@ -47,9 +31,9 @@ def test_pn_vs_sklearn(rho, X_density, fit_intercept):
     prox_solver = ProxNewton(fit_intercept=fit_intercept, tol=1e-12)
     w = prox_solver.solve(X, y, log_datafit, l1_penalty)[0]
 
-    np.testing.assert_allclose(w[:n_features], sk_log_reg.coef_.flatten(), atol=1e-9),
+    np.testing.assert_allclose(w[:n_features], sk_log_reg.coef_.flatten())
     if fit_intercept:
-        np.testing.assert_allclose(w[-1], sk_log_reg.intercept_, rtol=1e-4, atol=1e-3)
+        np.testing.assert_allclose(w[-1], sk_log_reg.intercept_)
 
 
 if __name__ == '__main__':

--- a/skglm/tests/test_prox_newton.py
+++ b/skglm/tests/test_prox_newton.py
@@ -39,8 +39,8 @@ def test_pn_vs_sklearn(rho, X_density, fit_intercept):
     alpha = rho * alpha_max
 
     sk_log_reg = LogisticRegression(penalty='l1', C=1/(n_samples * alpha),
-                                    fit_intercept=fit_intercept,
-                                    tol=1e-9, solver='saga', max_iter=100_000)
+                                    fit_intercept=fit_intercept, random_state=0,
+                                    tol=1e-9, solver='saga', max_iter=1_000_000)
     sk_log_reg.fit(X, y)
 
     log_datafit = compiled_clone(Logistic())
@@ -49,7 +49,9 @@ def test_pn_vs_sklearn(rho, X_density, fit_intercept):
     w = prox_solver.solve(X, y, log_datafit, l1_penalty)[0]
 
     np.testing.assert_allclose(w[:n_features], sk_log_reg.coef_.flatten(),
-                               rtol=1e-6, atol=1e-6)
+                               rtol=1e-4, atol=1e-3)
+    if fit_intercept:
+        np.testing.assert_allclose(w[-1], sk_log_reg.intercept_, rtol=1e-4, atol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds unpenalized intercept support to ``ProxNewton`` solver and closes #68.
It proceeds as follows
- [x] implement fit intercept
- [x] add unitest
- [x] perform benchmarks

-------------------
[View benchmark results](https://badr-moufad.github.io/share-benchmarks/pn-intercept/benchmark_logreg_l1_benchopt_run_2022-10-04_08h33m33.html)
[Link to benchmark repository](https://github.com/Badr-MOUFAD/benchmark_logreg_l1/tree/bench-intercept)