### PR TITLE
DOC - add solvers to documentation

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -58,4 +58,17 @@ Datafits
    QuadraticSVC
 
 
+Solvers
+=======
 
+.. currentmodule:: skglm.solvers
+
+.. autosummary::
+   :toctree: generated/
+
+   AndersonCD
+   GramCD
+   GroupBCD
+   MultiTaskBCD
+   ProxNewton
+   


### PR DESCRIPTION
Following https://github.com/scikit-learn-contrib/skglm/pull/75#issuecomment-1264996637, this adds all solvers to the API section in the documentation.

--------
[check build](https://output.circle-artifacts.com/output/job/831fe8bf-3671-4f34-8a50-20aaf28af871/artifacts/0/dev/api.html)