### PR TITLE
FIX Remove Numba warning when fitting multi-task estimators

### DIFF
--- a/skglm/datafits/multi_task.py
+++ b/skglm/datafits/multi_task.py
@@ -68,7 +68,7 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
     def gradient_j(self, X, Y, W, XW, j):
         """Gradient with respect to j-th coordinate of W."""
         n_samples = X.shape[0]
-        return (X[:, j:j+1].T @ XW - self.XtY[j, :]) / n_samples
+        return (X[:, j].T @ XW - self.XtY[j, :]) / n_samples
 
     def gradient_j_sparse(self, X_data, X_indptr, X_indices, Y, XW, j):
         """Gradient with respect to j-th coordinate of W when X is sparse."""

--- a/skglm/datafits/multi_task.py
+++ b/skglm/datafits/multi_task.py
@@ -68,7 +68,7 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
     def gradient_j(self, X, Y, W, XW, j):
         """Gradient with respect to j-th coordinate of W."""
         n_samples = X.shape[0]
-        return (X[:, j].T @ XW - self.XtY[j, :]) / n_samples
+        return (X[:, j] @ XW - self.XtY[j, :]) / n_samples
 
     def gradient_j_sparse(self, X_data, X_indptr, X_indices, Y, XW, j):
         """Gradient with respect to j-th coordinate of W when X is sparse."""

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -369,8 +369,8 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
             continue
         Xj = X[:, j]
         old_W_j = W[j, :].copy()  # copy is very important here
-        W[j:j+1, :] = penalty.prox_1feat(
-            W[j:j+1, :] - datafit.gradient_j(X, Y, W, XW, j) / lc[j],
+        W[j, :] = penalty.prox_1feat(
+            W[j, :] - datafit.gradient_j(X, Y, W, XW, j) / lc[j],
             1 / lc[j], j)
         if not np.all(W[j, :] == old_W_j):
             for k in range(n_tasks):


### PR DESCRIPTION
Currently, when fitting a multi-task estimator, Numba is raising this warning (visible when doing benchmarks for instance):

```
/Users/pierre-antoine/Documents/skglm/skglm/solvers/multitask_bcd.py:294: NumbaPerformanceWarning: '@' is faster on contiguous arrays, called on (array(float64, 2d, A), array(float64, 2d, C))
  grad[idx, :] = datafit.gradient_j(X, Y, W, XW, j)
/Users/pierre-antoine/Documents/skglm/skglm/solvers/multitask_bcd.py:294: NumbaPerformanceWarning: '@' is faster on contiguous arrays, called on (array(float64, 2d, A), array(float64, 2d, C))
  grad[idx, :] = datafit.gradient_j(X, Y, W, XW, j)
```

The warning was caused by the following indexation `W[j:j+1, :]`, which can be simply changed to `W[j, :]`. No improvements (nor degradation) in speed have been observed.

(Something discovered by @QB3 in #39 )