### PR TITLE
FIX - unit tests break down for ``SqrtLasso``

### DIFF
--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -146,7 +146,8 @@ class SqrtLasso(LinearModel, RegressorMixin):
         """
         if not hasattr(self, "solver_"):
             self.solver_ = ProxNewton(
-                tol=self.tol, max_iter=self.max_iter, verbose=self.verbose)
+                tol=self.tol, max_iter=self.max_iter, verbose=self.verbose,
+                fit_intercept=False)
         # build path
         if alphas is None:
             alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(len(y)) * norm(y))


### PR DESCRIPTION
This fixes the CI pytest which breaks for ``SqrtLasso`` unittests.

cf. https://github.com/scikit-learn-contrib/skglm/actions/runs/3259121285/jobs/5351722084#step:5:393

