### PR TITLE
Fix gradient sign convention in ``GroupBCD`` and  ``WeightedGroupL2``

### DIFF
--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -286,8 +286,8 @@ class WeightedGroupL2(BasePenalty):
     def subdiff_distance(self, w, grad_ws, ws):
         """Compute distance to the subdifferential at ``w`` of negative gradient.
 
-        Note: ``grad_ws`` is a stacked array of ``-``gradients.
-        ([-grad_ws_1, -grad_ws_2, ...])
+        Note: ``grad_ws`` is a stacked array of gradients.
+        ([grad_ws_1, grad_ws_2, ...])
         """
         alpha, weights = self.alpha, self.weights
         grp_ptr, grp_indices = self.grp_ptr, self.grp_indices
@@ -307,7 +307,7 @@ class WeightedGroupL2(BasePenalty):
                 scores[idx] = max(0, norm(grad_g) - alpha * weights[g])
             else:
                 subdiff = alpha * weights[g] * w_g / norm_w_g
-                scores[idx] = norm(grad_g - subdiff)
+                scores[idx] = norm(grad_g + subdiff)
 
         return scores
 

--- a/skglm/solvers/group_bcd.py
+++ b/skglm/solvers/group_bcd.py
@@ -170,6 +170,6 @@ def _construct_grad(X, y, w, Xw, datafit, ws):
     grad_ptr = 0
     for g in ws:
         grad_g = datafit.gradient_g(X, y, w, Xw, g)
-        grads[grad_ptr: grad_ptr+len(grad_g)] = -grad_g
+        grads[grad_ptr: grad_ptr+len(grad_g)] = grad_g
         grad_ptr += len(grad_g)
     return grads


### PR DESCRIPTION
I realized that in ``_construct_grad`` of ``GroupBCD`` solver, we are computing ``-grad`` instead of ``grad``.

https://github.com/scikit-learn-contrib/skglm/blob/5457eda1272f2075a726cac12cbfb0669fd7f92b/skglm/solvers/group_bcd.py#L169-L175

This implies serious confusion:
- It's misleading as a variable name
- it's not the adopted conversion in the other penalties to compute ``subdiff_distance``

This homogenizes conventions.