### PR TITLE
NOMRG - Primal-Dual CD solver for non-smooth datafits

### DIFF
--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -1,0 +1,52 @@
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+
+from sklearn.linear_model import Lasso
+from skglm.utils import make_correlated_data
+
+from prototype.pd_lasso import fb_lasso, cp_lasso, _compute_obj
+
+
+EPS_FLOATING = 1e-10
+reg = 1e-1
+n_samples, n_features = 100, 100
+fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
+                          constrained_layout=True)
+
+for normalize, ax in zip([False, True], axarr):
+    A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
+    if normalize:
+        A /= norm(b, axis=0)
+
+    n_samples, n_features = A.shape
+    alpha_max = norm(A.T @ b, ord=np.inf)
+
+    alpha = reg * alpha_max
+
+    print(f"========== {normalize} ================")
+    # start = time.time()
+    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=10000)
+    # end = time.time()
+    # print("F&B time: ", end - start)
+
+    # start = time.time()
+    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=10000)
+    # end = time.time()
+    # print("CB time: ", end - start)
+
+    lasso = Lasso(fit_intercept=False,
+                  alpha=alpha / n_samples).fit(A, b)
+    w_start = lasso.coef_.flatten()
+    p_star = _compute_obj(b, A, w_start, alpha)
+
+    ax.semilogy(p_objs_cp - p_star, label="CP")
+    ax.semilogy(p_objs_fb - p_star, label="FB")
+
+    ax.legend()
+    ax.set_xlabel("iteration")
+    ax.set_title(f"Normalize={normalize}")
+
+fig.suptitle(f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
+axarr[0].set_ylabel("primal suboptimality")
+plt.show()

--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -53,8 +53,8 @@ for normalize, ax in zip([False, True], axarr):
     w_start = lasso.coef_.flatten()
     p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
 
-    ax.semilogy(p_objs_fb - p_star, label="FB")
-    ax.semilogy(p_objs_cp - p_star, label="CP")
+    ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
+    ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
     ax.semilogy(p_objs - p_star, label="forward-backward")
     ax.semilogy(p_objs_cd - p_star, label="cyclic CD")
 

--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -2,10 +2,11 @@ import numpy as np
 from numpy.linalg import norm
 import matplotlib.pyplot as plt
 
-from sklearn.linear_model import Lasso
+from celer import Lasso
 from skglm.utils import make_correlated_data
 
-from prototype.pd_lasso import fb_lasso, cp_lasso, _compute_obj
+from prototype.pd_lasso import (fb_lasso, cp_lasso, forward_backward,
+                                cd, _compute_obj)
 
 
 EPS_FLOATING = 1e-10
@@ -17,31 +18,45 @@ fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
 for normalize, ax in zip([False, True], axarr):
     A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
     if normalize:
-        A /= norm(b, axis=0)
+        A /= norm(A, axis=0)
 
     n_samples, n_features = A.shape
     alpha_max = norm(A.T @ b, ord=np.inf)
 
+    max_iter = 400
     alpha = reg * alpha_max
 
     print(f"========== {normalize} ================")
     # start = time.time()
-    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=1000)
+    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=max_iter)
     # end = time.time()
     # print("F&B time: ", end - start)
 
     # start = time.time()
-    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=1000)
+    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=max_iter)
     # end = time.time()
     # print("CB time: ", end - start)
 
-    lasso = Lasso(fit_intercept=False,
-                  alpha=alpha / n_samples).fit(A, b)
-    w_start = lasso.coef_.flatten()
-    p_star = _compute_obj(b, A, w_start, alpha)
+    # start = time.time()
+    w, p_objs = forward_backward(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("forward backward time: ", end - start)
 
-    ax.semilogy(p_objs_cp - p_star, label="CP")
+    # start = time.time()
+    w_cd, p_objs_cd = cd(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("cyclic CD time: ", end - start)
+
+    # find optimal val
+    lasso = Lasso(fit_intercept=False,
+                  alpha=alpha / n_samples, tol=EPS_FLOATING).fit(A, b)
+    w_start = lasso.coef_.flatten()
+    p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
+
     ax.semilogy(p_objs_fb - p_star, label="FB")
+    ax.semilogy(p_objs_cp - p_star, label="CP")
+    ax.semilogy(p_objs - p_star, label="forward-backward")
+    ax.semilogy(p_objs_cd - p_star, label="cyclic CD")
 
     ax.legend()
     ax.set_xlabel("iteration")

--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -10,7 +10,7 @@ from prototype.pd_lasso import fb_lasso, cp_lasso, _compute_obj
 
 EPS_FLOATING = 1e-10
 reg = 1e-1
-n_samples, n_features = 100, 100
+n_samples, n_features = 1000, 100
 fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
                           constrained_layout=True)
 
@@ -26,12 +26,12 @@ for normalize, ax in zip([False, True], axarr):
 
     print(f"========== {normalize} ================")
     # start = time.time()
-    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=10000)
+    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=1000)
     # end = time.time()
     # print("F&B time: ", end - start)
 
     # start = time.time()
-    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=10000)
+    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=1000)
     # end = time.time()
     # print("CB time: ", end - start)
 

--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -62,8 +62,8 @@ for normalize, ax in zip([False, True], axarr):
     w_start = lasso.coef_.flatten()
     p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
 
-    ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
-    ax.semilogy(pb_obj_fb_lasso - p_star, label="Lasso F&B")
+    ax.semilogy(p_objs_fb - p_star, label="my Fercoq & Bianchi")
+    ax.semilogy(pb_obj_fb_lasso - p_star, label="his Fercoq & Bianchi")
     ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
     ax.semilogy(p_objs - p_star, label="forward-backward")
     ax.semilogy(p_objs_cd - p_star, label="cyclic CD")
@@ -72,6 +72,7 @@ for normalize, ax in zip([False, True], axarr):
     ax.set_xlabel("iteration")
     ax.set_title(f"Normalize={normalize}")
 
-fig.suptitle(f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
+fig.suptitle("Lasso on dataset with\n"
+             f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
 axarr[0].set_ylabel("primal suboptimality")
 plt.show()

--- a/prototype/comparaison.py
+++ b/prototype/comparaison.py
@@ -3,6 +3,7 @@ from numpy.linalg import norm
 import matplotlib.pyplot as plt
 
 from celer import Lasso
+from cd_solver.sklearn_api import Lasso as fb_Lasso
 from skglm.utils import make_correlated_data
 
 from prototype.pd_lasso import (fb_lasso, cp_lasso, forward_backward,
@@ -11,7 +12,7 @@ from prototype.pd_lasso import (fb_lasso, cp_lasso, forward_backward,
 
 EPS_FLOATING = 1e-10
 reg = 1e-1
-n_samples, n_features = 1000, 100
+n_samples, n_features = 100, 500
 fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
                           constrained_layout=True)
 
@@ -47,6 +48,14 @@ for normalize, ax in zip([False, True], axarr):
     # end = time.time()
     # print("cyclic CD time: ", end - start)
 
+    # start = time.time()
+    fq_estimator = fb_Lasso(alpha, smooth_formulation=False,
+                            max_iter=max_iter)
+    fq_estimator.fit(A, b)
+    pb_obj_fb_lasso = fq_estimator.p_objs_
+    # end = time.time()
+    # print("cyclic CD time: ", end - start)
+
     # find optimal val
     lasso = Lasso(fit_intercept=False,
                   alpha=alpha / n_samples, tol=EPS_FLOATING).fit(A, b)
@@ -54,6 +63,7 @@ for normalize, ax in zip([False, True], axarr):
     p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
 
     ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
+    ax.semilogy(pb_obj_fb_lasso - p_star, label="Lasso F&B")
     ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
     ax.semilogy(p_objs - p_star, label="forward-backward")
     ax.semilogy(p_objs_cd - p_star, label="cyclic CD")

--- a/prototype/comparaison_reg.py
+++ b/prototype/comparaison_reg.py
@@ -1,0 +1,76 @@
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+
+from celer import Lasso
+from cd_solver.sklearn_api import Lasso as fb_Lasso
+from skglm.utils import make_correlated_data
+
+from prototype.pd_lasso import (fb_lasso, cp_lasso, forward_backward,
+                                cd, _compute_obj)
+
+
+EPS_FLOATING = 1e-10
+regs = [1e-1, 1e-2, 1e-3]
+n_samples, n_features = 300, 600
+fig, axarr = plt.subplots(1, len(regs), sharey=False, figsize=[8., 3],
+                          constrained_layout=True)
+
+for reg, ax in zip(regs, axarr):
+    A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
+
+    n_samples, n_features = A.shape
+    alpha_max = norm(A.T @ b, ord=np.inf)
+
+    max_iter = 400
+    alpha = reg * alpha_max
+
+    print(f"========== reg = {reg} ================")
+    # start = time.time()
+    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("F&B time: ", end - start)
+
+    # start = time.time()
+    w_cp, p_objs_cp = cp_lasso(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("CB time: ", end - start)
+
+    # start = time.time()
+    # w, p_objs = forward_backward(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("forward backward time: ", end - start)
+
+    # start = time.time()
+    # w_cd, p_objs_cd = cd(A, b, alpha, max_iter=max_iter)
+    # end = time.time()
+    # print("cyclic CD time: ", end - start)
+
+    # start = time.time()
+    fq_estimator = fb_Lasso(alpha, smooth_formulation=False,
+                            max_iter=max_iter)
+    fq_estimator.fit(A, b)
+    pb_obj_fb_lasso = fq_estimator.p_objs_
+    # end = time.time()
+    # print("cyclic CD time: ", end - start)
+
+    # find optimal val
+    lasso = Lasso(fit_intercept=False,
+                  alpha=alpha / n_samples, tol=EPS_FLOATING).fit(A, b)
+    w_start = lasso.coef_.flatten()
+    p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
+
+    ax.semilogy(p_objs_fb - p_star, label="my Fercoq & Bianchi")
+    ax.semilogy(pb_obj_fb_lasso - p_star, label="his Fercoq & Bianchi")
+    ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
+    # ax.semilogy(p_objs - p_star, label="forward-backward")
+    # ax.semilogy(p_objs_cd - p_star, label="cyclic CD")
+
+    ax.legend()
+    ax.set_xlabel("iteration")
+    ax.set_title(f"reg={reg}")
+
+fig.suptitle("Lasso on dataset with\n"
+             f"n_samples={n_samples}, n_features={n_features}")
+axarr[0].set_ylabel("primal suboptimality")
+plt.show()

--- a/prototype/comparaison_sqrt.py
+++ b/prototype/comparaison_sqrt.py
@@ -3,7 +3,7 @@ from numpy.linalg import norm
 import matplotlib.pyplot as plt
 
 from skglm.utils import make_correlated_data
-from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
+from skglm.experimental.sqrt_lasso import SqrtLasso
 
 from prototype.pd_sqrt_lasso import fb_sqrt_lasso, cp_sqrt_lasso, _compute_obj
 
@@ -31,22 +31,19 @@ for normalize, ax in zip([False, True], axarr):
 
     w_cp, p_objs_cp = cp_sqrt_lasso(A, b, alpha, max_iter=max_iter)
 
-    w_norm, _, p_objs_norm = _chambolle_pock_sqrt(
-        A, b, alpha / sqrt_n, max_iter=max_iter)
-
     # find optimal val
     lasso = SqrtLasso(alpha=alpha / sqrt_n, tol=EPS_FLOATING).fit(A, b)
     w_start = lasso.coef_.flatten()
     p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
 
-    ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
+    ax.semilogy(p_objs_fb - p_star, label="my Fercoq & Bianchi")
     ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
-    ax.semilogy(sqrt_n * p_objs_norm - p_star, label="M.M Chambolle Pock")
 
     ax.legend()
     ax.set_xlabel("iteration")
     ax.set_title(f"Normalize={normalize}")
 
-fig.suptitle(f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
+fig.suptitle("Sqrt Lasso on dataset with\n"
+             f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
 axarr[0].set_ylabel("primal suboptimality")
 plt.show()

--- a/prototype/comparaison_sqrt.py
+++ b/prototype/comparaison_sqrt.py
@@ -9,8 +9,8 @@ from prototype.pd_sqrt_lasso import fb_sqrt_lasso, cp_sqrt_lasso, _compute_obj
 
 
 EPS_FLOATING = 1e-10
-reg = 1e-1
-n_samples, n_features = 1000, 100
+reg = 1e-2
+n_samples, n_features = 1000, 200
 fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
                           constrained_layout=True)
 
@@ -41,7 +41,7 @@ for normalize, ax in zip([False, True], axarr):
 
     ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
     ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
-    ax.semilogy(sqrt_n * p_objs_norm - p_star, label="normalized Chambolle Pock")
+    ax.semilogy(sqrt_n * p_objs_norm - p_star, label="M.M Chambolle Pock")
 
     ax.legend()
     ax.set_xlabel("iteration")

--- a/prototype/comparaison_sqrt.py
+++ b/prototype/comparaison_sqrt.py
@@ -1,0 +1,52 @@
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+
+from skglm.utils import make_correlated_data
+from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
+
+from prototype.pd_sqrt_lasso import fb_sqrt_lasso, cp_sqrt_lasso, _compute_obj
+
+
+EPS_FLOATING = 1e-10
+reg = 1e-1
+n_samples, n_features = 1000, 100
+fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
+                          constrained_layout=True)
+
+for normalize, ax in zip([False, True], axarr):
+    A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
+    if normalize:
+        A /= norm(A, axis=0)
+
+    n_samples, n_features = A.shape
+    alpha_max = norm(A.T @ b, ord=np.inf) / norm(b)
+    sqrt_n = np.sqrt(n_samples)
+
+    max_iter = 400
+    alpha = reg * alpha_max
+
+    print(f"========== {normalize} ================")
+    w_fb, p_objs_fb = fb_sqrt_lasso(A, b, alpha, max_iter=max_iter)
+
+    w_cp, p_objs_cp = cp_sqrt_lasso(A, b, alpha, max_iter=max_iter)
+
+    w_norm, _, p_objs_norm = _chambolle_pock_sqrt(
+        A, b, alpha / sqrt_n, max_iter=max_iter)
+
+    # find optimal val
+    lasso = SqrtLasso(alpha=alpha / sqrt_n, tol=EPS_FLOATING).fit(A, b)
+    w_start = lasso.coef_.flatten()
+    p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
+
+    ax.semilogy(p_objs_fb - p_star, label="Fercoq & Bianchi")
+    ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
+    ax.semilogy(sqrt_n * p_objs_norm - p_star, label="normalized Chambolle Pock")
+
+    ax.legend()
+    ax.set_xlabel("iteration")
+    ax.set_title(f"Normalize={normalize}")
+
+fig.suptitle(f"n_samples={n_samples}, n_features={n_features}, reg={reg}")
+axarr[0].set_ylabel("primal suboptimality")
+plt.show()

--- a/prototype/comparison_sqrt_reg.py
+++ b/prototype/comparison_sqrt_reg.py
@@ -1,0 +1,47 @@
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+
+from skglm.utils import make_correlated_data
+from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
+
+from prototype.pd_sqrt_lasso import fb_sqrt_lasso, cp_sqrt_lasso, _compute_obj
+
+
+EPS_FLOATING = 1e-10
+regs = [1e-1, 1e-2, 1e-3]
+n_samples, n_features = 1000, 500
+fig, axarr = plt.subplots(1, len(regs), sharey=False, figsize=[8., 3],
+                          constrained_layout=True)
+
+for reg, ax in zip(regs, axarr):
+    A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
+
+    n_samples, n_features = A.shape
+    alpha_max = norm(A.T @ b, ord=np.inf) / norm(b)
+    sqrt_n = np.sqrt(n_samples)
+
+    max_iter = 400
+    alpha = reg * alpha_max
+
+    print(f"========== reg = {reg} ================")
+    w_fb, p_objs_fb = fb_sqrt_lasso(A, b, alpha, max_iter=max_iter)
+
+    w_cp, p_objs_cp = cp_sqrt_lasso(A, b, alpha, max_iter=max_iter)
+
+    # find optimal val
+    lasso = SqrtLasso(alpha=alpha / sqrt_n, tol=EPS_FLOATING).fit(A, b)
+    w_start = lasso.coef_.flatten()
+    p_star = _compute_obj(b, A, w_start, alpha) - EPS_FLOATING
+
+    ax.semilogy(p_objs_fb - p_star, label="my Fercoq & Bianchi")
+    ax.semilogy(p_objs_cp - p_star, label="Chambolle Pock")
+
+    ax.legend()
+    ax.set_xlabel("iteration")
+    ax.set_title(f"reg={reg}")
+
+fig.suptitle("Sqrt Lasso on dataset with\n"
+             f"n_samples={n_samples}, n_features={n_features}")
+axarr[0].set_ylabel("primal suboptimality")
+plt.show()

--- a/prototype/pd_lasso.py
+++ b/prototype/pd_lasso.py
@@ -24,11 +24,13 @@ def fb_lasso(A, b, alpha, max_iter=1000, verbose=0):
     # solves using Fercoq & Bianchi
     n_samples, n_features = A.shape
 
+    # my step sizes
     sigma = 1 / norm(A, ord=2)
     tau = 1 / norm(A, axis=0, ord=2)
 
-    # sigma = 1 / (2*n_features - 1)
-    # tau = 1 / norm(A, axis=0, ord=2) ** 2
+    # # step sizes in fercoq package
+    # sigma = max(1 / np.sqrt(norm(A, axis=0, ord=2)**2 * n_features))
+    # tau = 0.9 / (norm(A, axis=0, ord=2)**2 * sigma * n_features)
 
     all_features = np.arange(n_features)
     p_obj_out = []

--- a/prototype/pd_lasso.py
+++ b/prototype/pd_lasso.py
@@ -24,7 +24,7 @@ def fb_lasso(A, b, alpha, max_iter=1000, verbose=0):
     # solves using Fercoq & Bianchi
     n_samples, n_features = A.shape
 
-    sigma = 1 / (2 * n_features * norm(A, ord=2))
+    sigma = 1 / norm(A, ord=2)
     tau = 1 / norm(A, axis=0, ord=2)
 
     all_features = np.arange(n_features)

--- a/prototype/pd_lasso.py
+++ b/prototype/pd_lasso.py
@@ -1,0 +1,110 @@
+"""Solve an un-normalized Lasso problem using P-D method
+
+Problem reads::
+
+    min_x 1/2 * ||b - Ax||^2 + alpha ||x||_1
+
+Which can be recast as a saddle point problem::
+
+    max_y min_x <Ax, y> + g(x) - h*(y)
+
+where::
+
+    g(x) = alpha ||x||_1
+    h(z) = (1/2) * ||b - z||^2   <===> h*(y) = <y, b> + (1/2) * ||y||^2
+"""
+
+import numpy as np
+from numpy.linalg import norm
+
+from skglm.utils import ST, ST_vec
+
+
+def fb_lasso(A, b, alpha, max_iter=1000, verbose=0):
+    # solves using Fercoq & Bianchi
+    n_samples, n_features = A.shape
+
+    sigma = 1 / (2 * n_features * norm(A, ord=2))
+    tau = 1 / norm(A, axis=0, ord=2)
+
+    all_features = np.arange(n_features)
+    p_obj_out = []
+
+    # primal variables
+    x = np.zeros(n_features)
+
+    # dual variables
+    y = np.zeros(n_samples)
+    y_bar = np.zeros(n_samples)
+
+    for iter in range(max_iter):
+
+        for j in all_features:
+            # primal update
+            old_x_j = x[j]
+            x[j] = _prox_g_j(old_x_j - tau[j] * (A[:, j] @ (2 * y_bar - y)), tau[j],
+                             alpha, b, A)
+
+            # dual update
+            y_bar = _prox_h_star(y + sigma * (A @ x), sigma,
+                                 b, A)
+            y += (y_bar - y) / n_features
+
+            if verbose:
+                print(f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}")
+
+        p_obj_out.append(_compute_obj(b, A, x, alpha))
+
+    return x, p_obj_out
+
+
+def cp_lasso(A, b, alpha, max_iter=1000, verbose=0):
+    # using Chambolle Pock
+    n_samples, n_features = A.shape
+
+    L = norm(A, ord=2)
+    sigma = 1 / L
+    tau = 1 / L
+
+    p_obj_out = []
+
+    # primal var
+    x = np.zeros(n_features)
+    x_bar = np.zeros(n_features)
+
+    # dual var
+    y = np.zeros(n_samples)
+
+    for iter in range(max_iter):
+
+        # dual update
+        y = _prox_h_star(y + sigma * (A @ x_bar), sigma, b, A)
+
+        # primal update
+        old_x = x.copy()
+        x = _prox_g(x - tau * (A.T @ y), tau, alpha, b, A)
+        x_bar = 2 * x - old_x
+
+        if verbose:
+            print(f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}")
+
+        p_obj_out.append(_compute_obj(b, A, x, alpha))
+
+    return x, p_obj_out
+
+
+def _compute_obj(b, A, x, alpha):
+    return ((1/2) * norm(b - A @ x, ord=2) ** 2
+            + alpha * norm(x, ord=1))
+
+
+def _prox_g_j(x_j, step, alpha, b, A):
+    return ST(x_j, step * alpha)
+
+
+def _prox_g(x, step, alpha, b, A):
+    return ST_vec(x, step * alpha)
+
+
+def _prox_h_star(y, step, b, A):
+    return (y/step - b) / (1 + 1/step)

--- a/prototype/pd_lasso.py
+++ b/prototype/pd_lasso.py
@@ -27,6 +27,9 @@ def fb_lasso(A, b, alpha, max_iter=1000, verbose=0):
     sigma = 1 / norm(A, ord=2)
     tau = 1 / norm(A, axis=0, ord=2)
 
+    # sigma = 1 / (2*n_features - 1)
+    # tau = 1 / norm(A, axis=0, ord=2) ** 2
+
     all_features = np.arange(n_features)
     p_obj_out = []
 
@@ -50,8 +53,12 @@ def fb_lasso(A, b, alpha, max_iter=1000, verbose=0):
                                  b, A)
             y += (y_bar - y) / n_features
 
-            if verbose:
-                print(f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}")
+        # print(norm(old_x - x), norm(old_y - y))
+        if verbose:
+            print(
+                f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}, "
+                f"support: {(x != 0).sum()}"
+            )
 
         p_obj_out.append(_compute_obj(b, A, x, alpha))
 
@@ -152,3 +159,20 @@ def _prox_g(x, step, alpha, b, A):
 
 def _prox_h_star(y, step, b, A):
     return (y/step - b) / (1 + 1/step)
+
+
+if __name__ == '__main__':
+    from skglm.utils import make_correlated_data
+
+    reg = 9 * 1e-2
+    n_samples, n_features = 100, 10
+
+    A, b, _ = make_correlated_data(n_samples, n_features, random_state=24)
+
+    n_samples, n_features = A.shape
+    alpha_max = norm(A.T @ b, ord=np.inf)
+
+    max_iter = 60
+    alpha = reg * alpha_max
+
+    w_fb, p_objs_fb = fb_lasso(A, b, alpha, max_iter=max_iter, verbose=0)

--- a/prototype/pd_sqrt_lasso.py
+++ b/prototype/pd_sqrt_lasso.py
@@ -1,0 +1,111 @@
+"""Solve an un-normalized Lasso problem using P-D method
+
+Problem reads::
+
+    min_x ||b - Ax|| + alpha ||x||_1
+
+Which can be recast as a saddle point problem::
+
+    max_y min_x <Ax, y> + g(x) - h*(y)
+
+where::
+
+    g(x) = alpha ||x||_1
+    h(z) = ||b - z||  <===>  h*(y) = <y, b> + ||.||^*(-y)
+"""
+
+import numpy as np
+from numpy.linalg import norm
+
+from skglm.utils import ST, ST_vec, proj_L2ball
+
+
+def fb_sqrt_lasso(A, b, alpha, max_iter=1000, verbose=0):
+    # solves using Fercoq & Bianchi
+    n_samples, n_features = A.shape
+
+    sigma = 1 / norm(A, ord=2)
+    tau = 1 / norm(A, axis=0, ord=2)
+
+    all_features = np.arange(n_features)
+    p_obj_out = []
+
+    # primal variables
+    x = np.zeros(n_features)
+
+    # dual variables
+    y = np.zeros(n_samples)
+    y_bar = np.zeros(n_samples)
+
+    for iter in range(max_iter):
+
+        for j in all_features:
+            # primal update
+            old_x_j = x[j]
+            x[j] = _prox_g_j(old_x_j - tau[j] * (A[:, j] @ (2 * y_bar - y)), tau[j],
+                             alpha, b, A)
+
+            # dual update
+            y_bar = _prox_h_star(y + sigma * (A @ x), sigma,
+                                 b, A)
+            y += (y_bar - y) / n_features
+
+            if verbose:
+                print(f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}")
+
+        p_obj_out.append(_compute_obj(b, A, x, alpha))
+
+    return x, p_obj_out
+
+
+def cp_sqrt_lasso(A, b, alpha, max_iter=1000, verbose=0):
+    # using Chambolle Pock
+    n_samples, n_features = A.shape
+
+    L = norm(A, ord=2)
+    sigma = 1 / L
+    tau = 1 / L
+
+    p_obj_out = []
+
+    # primal var
+    x = np.zeros(n_features)
+    x_bar = np.zeros(n_features)
+
+    # dual var
+    y = np.zeros(n_samples)
+
+    for iter in range(max_iter):
+
+        # dual update
+        y = _prox_h_star(y + sigma * (A @ x_bar), sigma, b, A)
+
+        # primal update
+        old_x = x.copy()
+        x = _prox_g(x - tau * (A.T @ y), tau, alpha, b, A)
+        x_bar = 2 * x - old_x
+
+        if verbose:
+            print(f"Iter {iter+1}: {_compute_obj(b, A, x, alpha):.10f}")
+
+        p_obj_out.append(_compute_obj(b, A, x, alpha))
+
+    return x, p_obj_out
+
+
+# utils
+def _compute_obj(b, A, x, alpha):
+    return (norm(b - A @ x, ord=2)
+            + alpha * norm(x, ord=1))
+
+
+def _prox_g_j(x_j, step, alpha, b, A):
+    return ST(x_j, step * alpha)
+
+
+def _prox_g(x, step, alpha, b, A):
+    return ST_vec(x, step * alpha)
+
+
+def _prox_h_star(y, step, b, A):
+    return proj_L2ball(y - step * b)

--- a/prototype/test_protype.py
+++ b/prototype/test_protype.py
@@ -4,9 +4,11 @@ import numpy as np
 from numpy.linalg import norm
 
 from sklearn.linear_model import Lasso
+from skglm.experimental import SqrtLasso
 from skglm.utils import make_correlated_data
 
 from prototype.pd_lasso import cp_lasso, fb_lasso, forward_backward, cd
+from prototype.pd_sqrt_lasso import fb_sqrt_lasso, cp_sqrt_lasso
 
 
 @pytest.mark.parametrize('solver', [fb_lasso, cp_lasso, forward_backward, cd])
@@ -26,5 +28,22 @@ def test_solver(solver):
     np.testing.assert_allclose(w, lasso.coef_.flatten(), atol=1e-4)
 
 
+@pytest.mark.parametrize('solver', [fb_sqrt_lasso, cp_sqrt_lasso])
+def test_solver(solver):
+    rho = 0.1
+    n_samples, n_features = 50, 10
+    A, b, _ = make_correlated_data(n_samples, n_features,
+                                   random_state=0)
+
+    alpha_max = norm(A.T @ b, ord=np.inf) / norm(b)
+    alpha = rho * alpha_max
+
+    w, _ = solver(A, b, alpha, max_iter=1000)
+    lasso = SqrtLasso(alpha=alpha / np.sqrt(n_samples), tol=1e-9).fit(A, b)
+
+    np.testing.assert_allclose(w, lasso.coef_.flatten(), atol=1e-4)
+
+
 if __name__ == '__main__':
+    test_solver(fb_sqrt_lasso)
     pass

--- a/prototype/test_protype.py
+++ b/prototype/test_protype.py
@@ -6,10 +6,10 @@ from numpy.linalg import norm
 from sklearn.linear_model import Lasso
 from skglm.utils import make_correlated_data
 
-from prototype.pd_lasso import cp_lasso, fb_lasso
+from prototype.pd_lasso import cp_lasso, fb_lasso, forward_backward, cd
 
 
-@pytest.mark.parametrize('solver', [fb_lasso, cp_lasso])
+@pytest.mark.parametrize('solver', [fb_lasso, cp_lasso, forward_backward, cd])
 def test_solver(solver):
     rho = 0.1
     n_samples, n_features = 50, 10

--- a/prototype/test_protype.py
+++ b/prototype/test_protype.py
@@ -1,0 +1,30 @@
+import pytest
+
+import numpy as np
+from numpy.linalg import norm
+
+from sklearn.linear_model import Lasso
+from skglm.utils import make_correlated_data
+
+from prototype.pd_lasso import cp_lasso, fb_lasso
+
+
+@pytest.mark.parametrize('solver', [fb_lasso, cp_lasso])
+def test_solver(solver):
+    rho = 0.1
+    n_samples, n_features = 50, 10
+    A, b, _ = make_correlated_data(n_samples, n_features,
+                                   random_state=0)
+
+    alpha_max = norm(A.T @ b, ord=np.inf) / 2
+    alpha = rho * alpha_max
+
+    w, _ = solver(A, b, alpha, max_iter=1000)
+    lasso = Lasso(fit_intercept=False,
+                  alpha=alpha / n_samples).fit(A, b)
+
+    np.testing.assert_allclose(w, lasso.coef_.flatten(), atol=1e-4)
+
+
+if __name__ == '__main__':
+    pass

--- a/prototype/test_protype.py
+++ b/prototype/test_protype.py
@@ -16,7 +16,7 @@ def test_solver(solver):
     A, b, _ = make_correlated_data(n_samples, n_features,
                                    random_state=0)
 
-    alpha_max = norm(A.T @ b, ord=np.inf) / 2
+    alpha_max = norm(A.T @ b, ord=np.inf)
     alpha = rho * alpha_max
 
     w, _ = solver(A, b, alpha, max_iter=1000)

--- a/skglm/experimental/_plot_comparaison.py
+++ b/skglm/experimental/_plot_comparaison.py
@@ -1,0 +1,55 @@
+import numpy as np
+from numpy.linalg import norm
+import matplotlib.pyplot as plt
+from skglm.utils import make_correlated_data, compiled_clone
+from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
+
+from skglm.penalties import L1
+from skglm.experimental.sqrt_lasso import SqrtQuadratic
+from skglm.experimental.fercoq_bianchi import fercoq_bianchi
+
+
+fig, axarr = plt.subplots(1, 2, sharey=True, figsize=[8., 3],
+                          constrained_layout=True)
+# for normalize, ax in zip([False, True], axarr):
+for normalize, ax in zip([True, False], axarr):
+    X, y, _ = make_correlated_data(n_samples=100, n_features=50, random_state=24)
+    if normalize:
+        X /= norm(X, axis=0) ** 2
+
+    n_samples, n_features = X.shape
+    alpha_max = norm(X.T @ y, ord=np.inf) / (norm(y) * np.sqrt(n_samples))
+
+    alpha = alpha_max / 10
+
+    max_iter = 1000
+    obj_freq = 10
+    verbose = False
+
+    datafit = compiled_clone(SqrtQuadratic())
+    penalty = compiled_clone(L1(alpha))
+
+    w_cd, objs_cd, _ = fercoq_bianchi(
+        X, y, datafit, penalty, max_iter=max_iter, verbose=verbose, tol=1e-6)
+
+    w, _, objs = _chambolle_pock_sqrt(
+        X, y, alpha, max_iter=max_iter, obj_freq=obj_freq, verbose=verbose)
+
+    # no convergence issue if n_features < n_samples, can use ProxNewton
+    # clf = SqrtLasso(alpha=alpha / np.sqrt(n_samples), verbose=2, tol=1e-10)
+    clf = SqrtLasso(alpha=alpha, verbose=0, tol=1e-10)
+    clf.fit(X, y)
+
+    # consider that our solver has converged
+    w_star = clf.coef_
+    p_star = norm(X @ w_star - y) / np.sqrt(n_samples) + alpha * norm(w_star, ord=1)
+
+    # p_star = min(np.min(objs), np.min(objs_cd))
+    # plt.close('all')
+    ax.semilogy(objs - p_star, label="CP")
+    ax.semilogy(objs_cd - p_star, label="FB")
+    ax.legend()
+    ax.set_xlabel("iteration")
+    ax.set_title(f"Normalize={normalize}")
+axarr[0].set_ylabel("primal suboptimality")
+plt.show()

--- a/skglm/experimental/_plot_comparaison.py
+++ b/skglm/experimental/_plot_comparaison.py
@@ -8,44 +8,62 @@ from skglm.penalties import L1
 from skglm.experimental.sqrt_lasso import SqrtQuadratic
 from skglm.experimental.fercoq_bianchi import fercoq_bianchi
 
+import time
 
-fig, axarr = plt.subplots(1, 2, sharey=True, figsize=[8., 3],
+
+def find_p_star(*args):
+    global X, y, alpha
+    EPS_FLOATING = 1e-10
+
+    def sqrt_lasso_obj(w):
+        return norm(X @ w - y) / np.sqrt(len(y)) + alpha * norm(w, ord=1)
+
+    p_objs = [sqrt_lasso_obj(coef)
+              for coef in args]
+
+    # run sqrt lasso
+    clf = SqrtLasso(alpha=alpha, tol=1e-10)
+    clf.fit(X, y)
+
+    p_objs.append(sqrt_lasso_obj(clf.coef_.flatten()))
+
+    return min(p_objs) - EPS_FLOATING
+
+
+fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
                           constrained_layout=True)
 # for normalize, ax in zip([False, True], axarr):
 for normalize, ax in zip([False, True], axarr):
     X, y, _ = make_correlated_data(n_samples=100, n_features=100, random_state=24)
     if normalize:
-        X /= norm(X, axis=0) ** 2
+        X /= norm(X, axis=0)
 
     n_samples, n_features = X.shape
     alpha_max = norm(X.T @ y, ord=np.inf) / (norm(y) * np.sqrt(n_samples))
 
     alpha = alpha_max / 10
-
     max_iter = 1000
-    obj_freq = 10
-    verbose = False
 
+    # cache numba
     datafit = compiled_clone(SqrtQuadratic())
     penalty = compiled_clone(L1(alpha))
+    # fercoq_bianchi(X, y, datafit, penalty, max_iter=2)
 
+    print(f"========== {normalize} ================")
+    start = time.time()
     w_cd, objs_cd, _ = fercoq_bianchi(
-        X, y, datafit, penalty, max_iter=max_iter, verbose=verbose, tol=1e-6)
+        X, y, datafit, penalty, max_iter=max_iter, tol=1e-6)
+    end = time.time()
+    # print("F&B time: ", end - start)
 
+    start = time.time()
     w, _, objs = _chambolle_pock_sqrt(
-        X, y, alpha, max_iter=max_iter, obj_freq=obj_freq, verbose=verbose)
+        X, y, alpha, max_iter=max_iter, obj_freq=10)
+    end = time.time()
+    # print("CB time: ", end - start)
 
-    # no convergence issue if n_features < n_samples, can use ProxNewton
-    # clf = SqrtLasso(alpha=alpha / np.sqrt(n_samples), verbose=2, tol=1e-10)
-    clf = SqrtLasso(alpha=alpha, verbose=0, tol=1e-10)
-    clf.fit(X, y)
-
-    # consider that our solver has converged
-    w_star = clf.coef_
-    p_star = norm(X @ w_star - y) / np.sqrt(n_samples) + alpha * norm(w_star, ord=1)
-
-    # p_star = min(np.min(objs), np.min(objs_cd))
     # plt.close('all')
+    p_star = find_p_star(w, w_cd)
     ax.semilogy(objs - p_star, label="CP")
     ax.semilogy(objs_cd - p_star, label="FB")
     ax.legend()

--- a/skglm/experimental/_plot_comparaison.py
+++ b/skglm/experimental/_plot_comparaison.py
@@ -12,8 +12,8 @@ from skglm.experimental.fercoq_bianchi import fercoq_bianchi
 fig, axarr = plt.subplots(1, 2, sharey=True, figsize=[8., 3],
                           constrained_layout=True)
 # for normalize, ax in zip([False, True], axarr):
-for normalize, ax in zip([True, False], axarr):
-    X, y, _ = make_correlated_data(n_samples=100, n_features=50, random_state=24)
+for normalize, ax in zip([False, True], axarr):
+    X, y, _ = make_correlated_data(n_samples=100, n_features=100, random_state=24)
     if normalize:
         X /= norm(X, axis=0) ** 2
 

--- a/skglm/experimental/_plot_comparaison.py
+++ b/skglm/experimental/_plot_comparaison.py
@@ -11,7 +11,7 @@ from skglm.experimental.fercoq_bianchi import fercoq_bianchi
 import time
 
 
-def find_p_star(*args):
+def _find_p_star(*args):
     global X, y, alpha
     EPS_FLOATING = 1e-10
 
@@ -63,7 +63,7 @@ for normalize, ax in zip([False, True], axarr):
     print("CB time: ", end - start)
 
     # plt.close('all')
-    p_star = find_p_star(w, w_cd)
+    p_star = _find_p_star(w, w_cd)
     ax.semilogy(objs - p_star, label="CP")
     ax.semilogy(objs_cd - p_star, label="FB")
     ax.legend()

--- a/skglm/experimental/_plot_comparaison.py
+++ b/skglm/experimental/_plot_comparaison.py
@@ -21,7 +21,7 @@ def find_p_star(*args):
     p_objs = [sqrt_lasso_obj(coef)
               for coef in args]
 
-    # run sqrt lasso
+    # fit sqrt lasso with Prox Newton
     clf = SqrtLasso(alpha=alpha, tol=1e-10)
     clf.fit(X, y)
 
@@ -34,7 +34,7 @@ fig, axarr = plt.subplots(1, 2, sharey=False, figsize=[8., 3],
                           constrained_layout=True)
 # for normalize, ax in zip([False, True], axarr):
 for normalize, ax in zip([False, True], axarr):
-    X, y, _ = make_correlated_data(n_samples=100, n_features=100, random_state=24)
+    X, y, _ = make_correlated_data(n_samples=100, n_features=50, random_state=24)
     if normalize:
         X /= norm(X, axis=0)
 
@@ -47,20 +47,20 @@ for normalize, ax in zip([False, True], axarr):
     # cache numba
     datafit = compiled_clone(SqrtQuadratic())
     penalty = compiled_clone(L1(alpha))
-    # fercoq_bianchi(X, y, datafit, penalty, max_iter=2)
+    fercoq_bianchi(X, y, datafit, penalty, max_iter=2)
 
     print(f"========== {normalize} ================")
     start = time.time()
     w_cd, objs_cd, _ = fercoq_bianchi(
         X, y, datafit, penalty, max_iter=max_iter, tol=1e-6)
     end = time.time()
-    # print("F&B time: ", end - start)
+    print("F&B time: ", end - start)
 
     start = time.time()
     w, _, objs = _chambolle_pock_sqrt(
         X, y, alpha, max_iter=max_iter, obj_freq=10)
     end = time.time()
-    # print("CB time: ", end - start)
+    print("CB time: ", end - start)
 
     # plt.close('all')
     p_star = find_p_star(w, w_cd)

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -80,7 +80,7 @@ def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
         _primal_dual_cd_epoch(y, X, w, Xw, z, datafit, penalty,
                               selected_features, sigma, tau)
 
-        # check convergence
+        # check convergence (so far only the primal optimally condition)
         if iter % 10 == 0:
             otp = penalty.subdiff_distance(w, X.T @ z, all_features)
             stop_crit = np.max(otp)

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -31,6 +31,10 @@ def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
         verbose : bool, default False
             Amount of verbosity. 0/False is silent.
 
+        random_state : int, default 0
+            The seed to control the randomly selected features to be updated
+            at each iteration.
+
     Returns
     -------
         w : array, shape (n_features,)

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -1,0 +1,81 @@
+from turtle import pen
+import numpy as np
+from numpy.linalg import norm
+
+from skglm.penalties import L1
+from skglm.experimental.sqrt_lasso import SqrtQuadratic, SqrtLasso
+
+from skglm.utils import make_correlated_data, compiled_clone
+
+
+def fercoq_bianchi(X, y, datafit, penalty, max_iter=100, tol=1e-4, verbose=0, random_state=0):
+    n_samples, n_features = X.shape
+    all_features = np.arange(n_features)
+    rng = np.random.RandomState(random_state)
+    stop_crit = 0.
+    p_objs_out = []
+
+    # primal variable
+    w = np.zeros(n_features)
+    Xw = np.zeros(n_samples)
+
+    # dual variable
+    z = np.zeros(n_samples)
+    z_bar = np.zeros(n_samples)
+
+    sigma = 1 / ((2 * n_features - 1) * norm(X, ord=2))
+    tau = 1 / (X ** 2).sum(axis=0)  # 1 / squared norm of columns
+
+    for iter in range(max_iter):
+
+        # random CD
+        for j in rng.choice(n_features, n_features):
+            # dual update
+            z_bar = datafit.prox_conjugate(y, X, z + sigma * Xw, sigma)
+            z += (z_bar - z) / n_features
+
+            # update primal
+            old_w_j = w[j]
+            w[j] = penalty.prox_1d(old_w_j - tau[j] * (X[:, j] @ (2 * z_bar - z)),
+                                   tau[j], j)
+
+            delta_w_j = w[j] - old_w_j
+            if delta_w_j != 0:
+                Xw += delta_w_j * X[:, j]
+
+        # check convergence
+        if iter % 10 == 0:
+            otp = penalty.subdiff_distance(w, X.T @ z, all_features)
+            stop_crit = np.max(otp)
+
+            if verbose:
+                p_obj = datafit.value(y, w, Xw) + penalty.value(w)
+                print(
+                    f"Iteration {iter+1}: {p_obj:.10f}, "
+                    f"stopping crit: {stop_crit:.2e}"
+                )
+
+            if stop_crit <= tol:
+                break
+
+        p_obj = datafit.value(y, w, Xw) + penalty.value(w)
+        p_objs_out.append(p_obj)
+    return w, np.asarray(p_objs_out), stop_crit
+
+
+if __name__ == '__main__':
+    rho = 1e-2
+    n_samples, n_features = 50, 10
+    X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
+    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+
+    alpha = rho * alpha_max
+    datafit = compiled_clone(SqrtQuadratic())
+    penalty = compiled_clone(L1(alpha))
+
+    w = fercoq_bianchi(X, y, datafit, penalty, max_iter=10_000, verbose=0, tol=1e-6)[0]
+
+    sqrt_lasso = SqrtLasso(alpha=alpha, tol=1e-6).fit(X, y)
+
+    print(norm(w - sqrt_lasso.coef_, ord=np.inf))
+    pass

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -73,10 +73,6 @@ def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
     sigma = 1 / ((2 * n_features - 1) * norm(X, ord=2))
     tau = 1 / (X ** 2).sum(axis=0)  # 1 / squared norm of columns
 
-    print("***F&B***")
-    print("sigma: ", sigma)
-    print("tau: ", max(tau))
-
     for iter in range(max_iter):
 
         # random CD with inplace update of w, Xw, and z
@@ -84,10 +80,13 @@ def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
         _primal_dual_cd_epoch(y, X, w, Xw, z, datafit, penalty,
                               selected_features, sigma, tau)
 
-        # check convergence (so far only the primal optimally condition)
+        # check convergence
         if iter % 10 == 0:
-            otp = penalty.subdiff_distance(w, X.T @ z, all_features)
-            stop_crit = np.max(otp)
+            otp_primal = np.max(penalty.subdiff_distance(w, X.T @ z, all_features))
+            # use: Xw in \partial datafit*(z) <==> z in \partial datafit(Xw)
+            opt_dual = datafit.subdiff_distance(y, z, Xw)
+
+            stop_crit = max(otp_primal, opt_dual)
 
             if verbose:
                 p_obj = datafit.value(y, w, Xw) + penalty.value(w)

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -73,6 +73,10 @@ def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
     sigma = 1 / ((2 * n_features - 1) * norm(X, ord=2))
     tau = 1 / (X ** 2).sum(axis=0)  # 1 / squared norm of columns
 
+    print("***F&B***")
+    print("sigma: ", sigma)
+    print("tau: ", max(tau))
+
     for iter in range(max_iter):
 
         # random CD with inplace update of w, Xw, and z

--- a/skglm/experimental/fercoq_bianchi.py
+++ b/skglm/experimental/fercoq_bianchi.py
@@ -2,8 +2,53 @@ import numpy as np
 from numpy.linalg import norm
 
 
-def fercoq_bianchi(X, y, datafit, penalty, max_iter=100, tol=1e-4,
+def fercoq_bianchi(X, y, datafit, penalty, max_iter=1000, tol=1e-4,
                    verbose=0, random_state=0):
+    """Primal-dual CD algorithm for problems with non-smooth datafits.
+
+    Adaptation of Fercoq & Bianchi primal-dual CD algorithm [1].
+
+    Parameters
+    ----------
+        X : array, shape (n_samples, n_features)
+            Training data.
+
+        y : array, shape (n_samples,)
+            Target values.
+
+        datafit : instance of Datafit class
+            Datafitting term.
+
+        penalty : instance of Penalty class
+            Penalty used in the model.
+
+        max_iter : int, default 1000
+            Maximum number of iterations.
+
+        tol : float, default 1e-4
+            Tolerance for convergence.
+
+        verbose : bool, default False
+            Amount of verbosity. 0/False is silent.
+
+    Returns
+    -------
+        w : array, shape (n_features,)
+            Regression coefficients.
+
+        p_objs_out : array, shape (n_iter,)
+            The objective values at every outer iteration.
+
+        stop_crit : float
+            Value of stopping criterion at convergence.
+
+    References
+    ----------
+    .. [1] Olivier Fercoq and Pascal Bianchi
+        "A Coordinate-Descent Primal-Dual Algorithm with Large Step Size and Possibly
+        Nonseparable Functions", SIAM Journal on Optimization, 2020,
+        https://epubs.siam.org/doi/10.1137/18M1168480
+    """
     n_samples, n_features = X.shape
     rng = np.random.RandomState(random_state)
     all_features = np.arange(n_features)

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -229,6 +229,10 @@ def _chambolle_pock_sqrt(X, y, alpha, max_iter=1000, obj_freq=10, verbose=False)
     tau = 0.99 / L
     sigma = 0.99 / L
 
+    print("***CB***")
+    print("sigma: ", sigma)
+    print("tau: ", tau)
+
     for t in range(max_iter):
         w = ST_vec(w - tau * X.T @ (2 * z - z_old), alpha * np.sqrt(n_samples) * tau)
         z_old = z.copy()

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -235,8 +235,9 @@ def _chambolle_pock_sqrt(X, y, alpha, max_iter=1000, obj_freq=10, verbose=False)
         z[:] = proj_L2ball(z + sigma * (X @ w - y))
 
         if t % obj_freq == 0:
-            objs.append(norm(X @ w - y) / np.sqrt(n_samples) + alpha * norm(w, ord=1))
+            # objs.append(norm(X @ w - y) / np.sqrt(n_samples) + alpha * norm(w, ord=1))
             if verbose:
                 print(f"Iter {t}, obj {objs[-1]: .10f}")
 
+        objs.append(norm(X @ w - y) / np.sqrt(n_samples) + alpha * norm(w, ord=1))
     return w, z, objs

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -52,6 +52,16 @@ class SqrtQuadratic(BaseDatafit):
         fill_value = 1 / (np.sqrt(n_samples) * norm(y - Xw))
         return np.full(n_samples, fill_value)
 
+    def prox_conjugate(self, y, X, v, stepsize):
+        """Computes the proximal operator of the Fenchel conjugate of datafit.
+
+        Solves::
+
+            arg min_u (datafit*(u) + 1 / (2 * stepsize) * ||u - v||^2)
+        """
+        sqrt_n = np.sqrt(len(y))
+        return proj_L2ball(sqrt_n * (v - stepsize * y)) / sqrt_n
+
 
 class SqrtLasso(LinearModel, RegressorMixin):
     """Square root Lasso estimator based on Prox Newton solver.

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -251,4 +251,4 @@ def _chambolle_pock_sqrt(X, y, alpha, max_iter=1000, obj_freq=10, verbose=False)
                 print(f"Iter {t}, obj {objs[-1]: .10f}")
 
         objs.append(norm(X @ w - y) / np.sqrt(n_samples) + alpha * norm(w, ord=1))
-    return w, z, objs
+    return w, z, np.asarray(objs)

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -62,6 +62,17 @@ class SqrtQuadratic(BaseDatafit):
         sqrt_n = np.sqrt(len(y))
         return proj_L2ball(sqrt_n * (v - stepsize * y)) / sqrt_n
 
+    def subdiff_distance(self, y, z, Xw):
+        """Computes the distance of z to the subdifferential of datafit at Xw."""
+        y_minus_Xw = y - Xw
+        norm_y_minus_Xw = norm(y_minus_Xw)
+        sqrt_n = np.sqrt(len(y))
+
+        if norm_y_minus_Xw == 0:
+            return norm(sqrt_n * z - proj_L2ball(z))
+        else:
+            return norm(sqrt_n * z + y_minus_Xw / norm_y_minus_Xw)
+
 
 class SqrtLasso(LinearModel, RegressorMixin):
     """Square root Lasso estimator based on Prox Newton solver.
@@ -228,10 +239,6 @@ def _chambolle_pock_sqrt(X, y, alpha, max_iter=1000, obj_freq=10, verbose=False)
     # take primal and dual stepsizes equal
     tau = 0.99 / L
     sigma = 0.99 / L
-
-    print("***CB***")
-    print("sigma: ", sigma)
-    print("tau: ", tau)
 
     for t in range(max_iter):
         w = ST_vec(w - tau * X.T @ (2 * z - z_old), alpha * np.sqrt(n_samples) * tau)

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -53,7 +53,7 @@ class SqrtQuadratic(BaseDatafit):
         return np.full(n_samples, fill_value)
 
     def prox_conjugate(self, y, X, v, stepsize):
-        """Computes the proximal operator of the Fenchel conjugate of datafit.
+        """Compute the proximal operator of the Fenchel conjugate of datafit.
 
         Solves::
 
@@ -63,7 +63,7 @@ class SqrtQuadratic(BaseDatafit):
         return proj_L2ball(sqrt_n * (v - stepsize * y)) / sqrt_n
 
     def subdiff_distance(self, y, z, Xw):
-        """Computes the distance of z to the subdifferential of datafit at Xw."""
+        """Compute the distance of z to the subdifferential of datafit at Xw."""
         y_minus_Xw = y - Xw
         norm_y_minus_Xw = norm(y_minus_Xw)
         sqrt_n = np.sqrt(len(y))


### PR DESCRIPTION
This suggests a primal-dual CD solver based on [Fercoq & Bianchi algorithm](https://epubs.siam.org/doi/10.1137/18M1168480) (F&B)

In terms of iteration, currently, the F&B solver doesn't quickly reach a good sub-optimality compared to [Chambolle Pock](https://hal.archives-ouvertes.fr/hal-00490826/document).

@mathurinm suspects that this has to do we the choice of step sizes.