### PR TITLE
ENH Add `L_11` matrix norm

### DIFF
--- a/skglm/penalties/__init__.py
+++ b/skglm/penalties/__init__.py
@@ -3,7 +3,7 @@ from .separable import (
     L1_plus_L2, L0_5, L1, L2_3, MCPenalty, SCAD, WeightedL1, IndicatorBox
 )
 from .block_separable import (
-    L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2
+    L2_05, L2_1, L1_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2
 )
 
 from .non_separable import SLOPE
@@ -12,5 +12,5 @@ from .non_separable import SLOPE
 __all__ = [
     BasePenalty,
     L1_plus_L2, L0_5, L1, L2_3, MCPenalty, SCAD, WeightedL1, IndicatorBox,
-    L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2, SLOPE
+    L2_05, L2_1, L1_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2, SLOPE
 ]

--- a/skglm/tests/test_penalties.py
+++ b/skglm/tests/test_penalties.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from numpy.linalg import norm
 from numpy.testing import assert_array_less
+from sklearn.linear_model import Lasso as Lasso_sk
 
 from skglm.datafits import Quadratic, QuadraticMultiTask
 from skglm.penalties import (
@@ -38,7 +39,7 @@ penalties = [
     L2_3(alpha)]
 
 block_penalties = [
-    L2_1(alpha=alpha), 
+    L2_1(alpha=alpha),
     L2_05(alpha=alpha),
     L1_1(alpha=alpha),
     BlockMCPenalty(alpha=alpha, gamma=4),
@@ -107,10 +108,11 @@ def test_l11():
     ours = GeneralizedLinearEstimator(
         datafit=QuadraticMultiTask(),
         penalty=L1_1(alpha),
-        solver=MultiTaskBCD(tol=tol, ws_strategy="fixpoint", max_iter=10),
+        solver=MultiTaskBCD(
+            tol=tol, ws_strategy="fixpoint", max_iter=1000, fit_intercept=False),
     ).fit(X, Y)
-    sk = Lasso(alpha, tol=tol, fit_intercept=False).fit(X, Y)
-    np.testing.assert_allclose(ours.coef_, sk.coef_, rtol=1e-5)
+    sk = Lasso_sk(alpha, tol=tol, fit_intercept=False).fit(X, Y)
+    np.testing.assert_allclose(ours.coef_, sk.coef_.T, rtol=1e-3)
 
 
 if __name__ == "__main__":

--- a/toy.py
+++ b/toy.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from skglm.penalties import L1_1
+from skglm.datafits import QuadraticMultiTask
+from skglm.estimators import GeneralizedLinearEstimator
+from skglm.solvers import MultiTaskBCD
+from skglm.utils import make_correlated_data
+
+from sklearn.linear_model import Lasso
+
+
+n_samples = 30
+n_features = 50
+n_tasks = 20
+
+
+X, Y, _ = make_correlated_data(
+    n_samples, n_features, n_tasks, density=0.2, random_state=0)
+
+alpha_max = np.max(X.T @ Y) / n_samples
+alpha = alpha_max * 0.01
+tol = 1e-8
+
+sk_clf = Lasso(alpha, fit_intercept=False, tol=tol).fit(X, Y)
+
+ours_clf = GeneralizedLinearEstimator(
+    datafit=QuadraticMultiTask(),
+    penalty=L1_1(alpha),
+    solver=MultiTaskBCD(
+        tol=tol, fit_intercept=False, max_iter=1000, verbose=2, ws_strategy="subdiff")
+).fit(X, Y)
+
+np.testing.assert_allclose(sk_clf.coef_.T, ours_clf.coef_, rtol=1e-3)


### PR DESCRIPTION
Quick PR to add the matrix L1 norm, I need it for sparse dictionary learning.

Note that in scikit-learn, the Lasso accept a target matrix and solves a multi-task objective with a L_11 penalty (see https://github.com/scikit-learn/scikit-learn/pull/24843) . As per the principle of least surprise, we should add it in the `Lasso` fit logic of skglm. 