### PR TITLE
MNT - remove normalization by ``sqrt(n_samples)`` in Square root Lasso

### DIFF
--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -12,7 +12,7 @@ from skglm.solvers.prox_newton import ProxNewton
 
 
 class SqrtQuadratic(BaseDatafit):
-    """Square root quadratic datafit.
+    """Unnormalized square root quadratic datafit.
 
     The datafit reads::
 

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -9,7 +9,7 @@ from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
 def test_alpha_max():
     n_samples, n_features = 50, 10
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
-    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
 
     sqrt_lasso = SqrtLasso(alpha=alpha_max).fit(X, y)
 
@@ -24,7 +24,7 @@ def test_vs_statsmodels():
     n_samples, n_features = 50, 10
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
 
-    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
     n_alphas = 3
     alphas = alpha_max * np.geomspace(1, 1e-2, n_alphas+1)[1:]
 
@@ -36,9 +36,10 @@ def test_vs_statsmodels():
     # fit statsmodels on path
     for i in range(n_alphas):
         alpha = alphas[i]
+        # statsmodel fits: ||y - Xw||_2 + alpha* ||w||_1 / sqrt(n_samples)
         model = linear_model.OLS(y, X)
         model = model.fit_regularized(method='sqrt_lasso', L1_wt=1.,
-                                      alpha=n_samples * alpha)
+                                      alpha=np.sqrt(n_samples) * alpha)
         coefs_statsmodels[i] = model.params
 
     np.testing.assert_almost_equal(coefs_skglm, coefs_statsmodels, decimal=4)

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -36,7 +36,7 @@ def test_vs_statsmodels():
     # fit statsmodels on path
     for i in range(n_alphas):
         alpha = alphas[i]
-        # statsmodel fits: ||y - Xw||_2 + alpha* ||w||_1 / sqrt(n_samples)
+        # statsmodels solves: ||y - Xw||_2 + alpha * ||w||_1 / sqrt(n_samples)
         model = linear_model.OLS(y, X)
         model = model.fit_regularized(method='sqrt_lasso', L1_wt=1.,
                                       alpha=np.sqrt(n_samples) * alpha)

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -49,7 +49,7 @@ def test_prox_newton_cp():
     n_samples, n_features = 50, 10
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
 
-    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
     alpha = alpha_max / 10
     clf = SqrtLasso(alpha=alpha, tol=1e-12).fit(X, y)
     w, _, _ = _chambolle_pock_sqrt(X, y, alpha, max_iter=1000)


### PR DESCRIPTION
Preparing the background for a primal-dual solver à la `skglm` since It turned out to be sensible to the scaling of the datafit and penalty terms.
In fact, it's difficult to keep track of the scaling constants (for our Square root Lasso it's $\\sqrt{n}$ and for LAD-Lasso it would be $n$) without hard coding them in the solver.

This changes the solved problem to:
$$\\min_w \\lVert y - Xw \\rVert_2 + \\alpha \\lVert w \\rVert_1$$

implicitly, it remove the $\\sqrt{n})$ from ``SqrtQuadratic`` datafit