### PR TITLE
ENH - add Primal-Dual Coordinate Descent solver à la skglm

### DIFF
--- a/skglm/experimental/pdcd_ws.py
+++ b/skglm/experimental/pdcd_ws.py
@@ -9,6 +9,48 @@ from sklearn.exceptions import ConvergenceWarning
 
 
 class PDCD_WS:
+    """Primal-Dual Coordinate Descent solver with working sets.
+
+    Solver inspired by [1] that uses working sets.
+
+    Parameters
+    ----------
+    max_iter : int, optional
+        The maximum number of iterations or equivalently the
+        the maximum number solved subproblems.
+
+    max_epochs : int, optional
+        Maximum number of CD epochs on each subproblem.
+
+    p0 : int, optional
+        First working set size.
+
+    tol : float, optional
+        The tolerance for the optimization.
+
+    dual_init : array, shape (n_samples,) default None
+        The initialization of dual variables.
+        If None, they are initialized as the 0 vector ``np.zeros(n_samples)``.
+
+    return_p_objs : bool, default False
+        If True, returns the values of the objective in each iteration.
+        Otherwise returns an empty array.
+
+    verbose : bool or int, default False
+        Amount of verbosity. 0/False is silent.
+
+    References
+    ----------
+    .. [1] Olivier Fercoq and Pascal Bianchi,
+        "A Coordinate-Descent Primal-Dual Algorithm with Large Step Size and Possibly
+        Nonseparable Functions", SIAM Journal on Optimization, 2020,
+        https://epubs.siam.org/doi/10.1137/18M1168480,
+        code: https://github.com/Badr-MOUFAD/Fercoq-Bianchi-solver
+
+    .. [2] Mathurin Massias, Alexandre Gramfort, Joseph Salmon,
+        "From safe screening rules to working sets for faster Lasso-type solvers",
+        OPTML workshop at NIPS 2017, https://arxiv.org/abs/1703.07285v2
+    """
 
     def __init__(self, max_iter=1000, max_epochs=1000, p0=100, tol=1e-6,
                  dual_init=None, return_p_objs=False, verbose=False):
@@ -131,11 +173,11 @@ class PDCD_WS:
                     break
 
     @staticmethod
-    def _validate_init(datafit, penalty):
+    def _validate_init(datafit_, penalty_):
         # validate datafit
         missing_attrs = []
         for attr in ('prox_conjugate', 'subdiff_distance'):
-            if not hasattr(datafit, attr):
+            if not hasattr(datafit_, attr):
                 missing_attrs.append(f"`{attr}`")
 
         if len(missing_attrs):
@@ -146,7 +188,7 @@ class PDCD_WS:
             )
 
         # jit compile classes
-        compiled_datafit = compiled_clone(datafit)
-        compiled_penalty = compiled_clone(penalty)
+        compiled_datafit = compiled_clone(datafit_)
+        compiled_penalty = compiled_clone(penalty_)
 
         return compiled_datafit, compiled_penalty

--- a/skglm/experimental/pdcd_ws.py
+++ b/skglm/experimental/pdcd_ws.py
@@ -46,7 +46,7 @@ class PDCD_WS:
         for iter in range(self.max_iter):
 
             # check convergence
-            opts_primal = penalty.subdiff_distance(X.T @ z, w, all_features)
+            opts_primal = penalty.subdiff_distance(w, X.T @ z, all_features)
             opt_dual = datafit.subdiff_distance(Xw, z, y)
 
             stop_crit = max(
@@ -55,13 +55,13 @@ class PDCD_WS:
             )
 
             if self.verbose:
-                current_p_obj = datafit.value(y, Xw) + penalty.value(w)
+                current_p_obj = datafit.value(y, w, Xw) + penalty.value(w)
                 print(
                     f"Iteration {iter+1}: {current_p_obj:.10f}, "
                     f"stopping crit: {stop_crit:.2e}")
 
             if self.return_p_objs:
-                current_p_obj = datafit.value(y, Xw) + penalty.value(w)
+                current_p_obj = datafit.value(y, w, Xw) + penalty.value(w)
                 p_objs.append(current_p_obj)
 
             if stop_crit <= self.tol:
@@ -82,7 +82,7 @@ class PDCD_WS:
                 primal_steps, dual_step, ws, self.max_epochs, tol_in=0.3*stop_crit)
         else:
             warnings.warn(
-                f"PDCD_WS did not converge for tol={self.tol:3.e} "
+                f"PDCD_WS did not converge for tol={self.tol:.3e} "
                 f"and max_iter={self.max_iter}.\n"
                 "Considering increasing `max_iter` or decreasing `tol`.",
                 category=ConvergenceWarning
@@ -105,7 +105,7 @@ class PDCD_WS:
                 past_pseudo_grad[idx] = X[:, j] @ (2 * z_bar - z)
                 w[j] = penalty.prox_1d(
                     old_w_j - primal_steps[j] * past_pseudo_grad[idx],
-                    primal_steps[j])
+                    primal_steps[j], j)
 
                 # keep Xw syncr with X @ w
                 delta_w_j = w[j] - old_w_j
@@ -119,7 +119,7 @@ class PDCD_WS:
 
             # check convergence
             if epoch % 10 == 0:
-                opts_primal_in = penalty.subdiff_distance(past_pseudo_grad, w, ws)
+                opts_primal_in = penalty.subdiff_distance(w, past_pseudo_grad, ws)
                 opt_dual_in = datafit.subdiff_distance(Xw, z, y)
 
                 stop_crit_in = max(

--- a/skglm/experimental/pdcd_ws.py
+++ b/skglm/experimental/pdcd_ws.py
@@ -1,0 +1,152 @@
+import warnings
+
+import numpy as np
+from numpy.linalg import norm
+
+from numba import njit
+from skglm.utils.jit_compilation import compiled_clone
+from sklearn.exceptions import ConvergenceWarning
+
+
+class PDCD_WS:
+
+    def __init__(self, max_iter=1000, max_epochs=1000, p0=100, tol=1e-6,
+                 dual_init=None, return_p_objs=False, verbose=False):
+        self.max_iter = max_iter
+        self.max_epochs = max_epochs
+        self.dual_init = dual_init
+        self.p0 = p0
+        self.tol = tol
+        self.verbose = verbose
+        self.return_p_objs = return_p_objs
+
+    def solve(self, X, y, datafit_, penalty_):
+        datafit, penalty = PDCD_WS._validate_init(datafit_, penalty_)
+        n_samples, n_features = X.shape
+
+        # init steps
+        dual_step = 1 / norm(X, ord=2)
+        primal_steps = 1 / norm(X, axis=0, ord=2)
+
+        # primal vars
+        w = np.zeros(n_features)
+        Xw = np.zeros(n_samples)
+
+        # dual vars
+        if self.dual_init is None:
+            z = np.zeros(n_samples)
+            z_bar = np.zeros(n_samples)
+        else:
+            z = self.dual_init.copy()
+            z_bar = self.dual_init.copy()
+
+        p_objs = []
+        all_features = np.arange(n_features)
+
+        for iter in range(self.max_iter):
+
+            # check convergence
+            opts_primal = penalty.subdiff_distance(X.T @ z, w, all_features)
+            opt_dual = datafit.subdiff_distance(Xw, z, y)
+
+            stop_crit = max(
+                max(opts_primal),
+                opt_dual
+            )
+
+            if self.verbose:
+                current_p_obj = datafit.value(y, Xw) + penalty.value(w)
+                print(
+                    f"Iteration {iter+1}: {current_p_obj:.10f}, "
+                    f"stopping crit: {stop_crit:.2e}")
+
+            if self.return_p_objs:
+                current_p_obj = datafit.value(y, Xw) + penalty.value(w)
+                p_objs.append(current_p_obj)
+
+            if stop_crit <= self.tol:
+                break
+
+            # build ws
+            gsupp_size = (w != 0).sum()
+            ws_size = max(min(self.p0, n_features),
+                          min(n_features, 2 * gsupp_size))
+
+            # similar to np.argsort()[-ws_size:] but without full sort
+            ws = np.argpartition(opts_primal, -ws_size)[-ws_size:]
+
+            # solve sub problem
+            # inplace update of w, Xw, z, z_bar
+            PDCD_WS._solve_subproblem(
+                y, X, w, Xw, z, z_bar, datafit, penalty,
+                primal_steps, dual_step, ws, self.max_epochs, tol_in=0.3*stop_crit)
+        else:
+            warnings.warn(
+                f"PDCD_WS did not converge for tol={self.tol:3.e} "
+                f"and max_iter={self.max_iter}.\n"
+                "Considering increasing `max_iter` or decreasing `tol`.",
+                category=ConvergenceWarning
+            )
+
+        return w, np.asarray(p_objs), stop_crit
+
+    @staticmethod
+    @njit
+    def _solve_subproblem(y, X, w, Xw, z, z_bar, datafit, penalty,
+                          primal_steps, dual_step, ws, max_epochs, tol_in):
+        n_features = X.shape[1]
+        past_pseudo_grad = np.zeros(len(ws))
+
+        for epoch in range(max_epochs):
+
+            for idx, j in enumerate(ws):
+                # update primal
+                old_w_j = w[j]
+                past_pseudo_grad[idx] = X[:, j] @ (2 * z_bar - z)
+                w[j] = penalty.prox_1d(
+                    old_w_j - primal_steps[j] * past_pseudo_grad[idx],
+                    primal_steps[j])
+
+                # keep Xw syncr with X @ w
+                delta_w_j = w[j] - old_w_j
+                if delta_w_j:
+                    Xw += delta_w_j * X[:, j]
+
+                # update dual
+                z_bar[:] = datafit.prox_conjugate(z + dual_step * Xw,
+                                                  dual_step, y)
+                z += (z_bar - z) / n_features
+
+            # check convergence
+            if epoch % 10 == 0:
+                opts_primal_in = penalty.subdiff_distance(past_pseudo_grad, w, ws)
+                opt_dual_in = datafit.subdiff_distance(Xw, z, y)
+
+                stop_crit_in = max(
+                    max(opts_primal_in),
+                    opt_dual_in
+                )
+
+                if stop_crit_in <= tol_in:
+                    break
+
+    @staticmethod
+    def _validate_init(datafit, penalty):
+        # validate datafit
+        missing_attrs = []
+        for attr in ('prox_conjugate', 'subdiff_distance'):
+            if not hasattr(datafit, attr):
+                missing_attrs.append(f"`{attr}`")
+
+        if len(missing_attrs):
+            raise AttributeError(
+                "Datafit is not compatible with PDCD_WS solver.\n"
+                "Datafit must implement `prox_conjugate` and `subdiff_distance`.\n"
+                f"Missing {' and '.join(missing_attrs)}."
+            )
+
+        # jit compile classes
+        compiled_datafit = compiled_clone(datafit)
+        compiled_penalty = compiled_clone(penalty)
+
+        return compiled_datafit, compiled_penalty

--- a/skglm/experimental/sqrt_lasso.py
+++ b/skglm/experimental/sqrt_lasso.py
@@ -55,16 +55,16 @@ class SqrtQuadratic(BaseDatafit):
         return np.full(n_samples, fill_value)
 
     def prox(self, w, step, y):
-        """prox of ||y - . || with step."""
+        """Prox of ||y - . || with step."""
         return y - BST(y - w, step)
 
     def prox_conjugate(self, z, step, y):
-        """prox of ||y - . ||^* with step using Moreau decomposition."""
+        """Prox of ||y - . ||^* with step using Moreau decomposition."""
         inv_step = 1 / step
         return z - step * self.prox(inv_step * z, inv_step, y)
 
     def subdiff_distance(self, Xw, z, y):
-        """distance of z to subdiff of ||y - . || at Xw."""
+        """Distance of ``z`` to subdiff of ||y - . || at ``Xw``."""
         # computation note: \partial ||y - . ||(Xw) = - \partial || . ||(y - Xw)
         y_minus_Xw = y - Xw
 

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -9,7 +9,7 @@ from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
 def test_alpha_max():
     n_samples, n_features = 50, 10
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
-    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
 
     sqrt_lasso = SqrtLasso(alpha=alpha_max).fit(X, y)
 
@@ -24,7 +24,7 @@ def test_vs_statsmodels():
     n_samples, n_features = 50, 10
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
 
-    alpha_max = norm(X.T @ y, ord=np.inf) / (np.sqrt(n_samples) * norm(y))
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
     n_alphas = 3
     alphas = alpha_max * np.geomspace(1, 1e-2, n_alphas+1)[1:]
 
@@ -36,9 +36,10 @@ def test_vs_statsmodels():
     # fit statsmodels on path
     for i in range(n_alphas):
         alpha = alphas[i]
+        # statsmodel fits: ||y - Xw||_2 + alpha* ||w||_1 / sqrt(n_samples)
         model = linear_model.OLS(y, X)
         model = model.fit_regularized(method='sqrt_lasso', L1_wt=1.,
-                                      alpha=n_samples * alpha)
+                                      alpha=np.sqrt(n_samples) * alpha)
         coefs_statsmodels[i] = model.params
 
     np.testing.assert_almost_equal(coefs_skglm, coefs_statsmodels, decimal=4)

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -2,8 +2,11 @@ import pytest
 import numpy as np
 from numpy.linalg import norm
 
+from skglm.penalties import L1
 from skglm.utils.data import make_correlated_data
-from skglm.experimental.sqrt_lasso import SqrtLasso, _chambolle_pock_sqrt
+from skglm.experimental.sqrt_lasso import (SqrtLasso, SqrtQuadratic,
+                                           _chambolle_pock_sqrt)
+from skglm.experimental.pdcd_ws import PDCD_WS
 
 
 def test_alpha_max():
@@ -51,6 +54,22 @@ def test_prox_newton_cp():
 
     alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
     alpha = alpha_max / 10
+    clf = SqrtLasso(alpha=alpha, tol=1e-12).fit(X, y)
+    w, _, _ = _chambolle_pock_sqrt(X, y, alpha, max_iter=1000)
+    np.testing.assert_allclose(clf.coef_, w)
+
+
+@pytest.mark.parametrize('with_dual_init', [True, False])
+def test_PDCD_WS(with_dual_init):
+    n_samples, n_features = 50, 10
+    X, y, _ = make_correlated_data(n_samples, n_features, random_state=0)
+
+    alpha_max = norm(X.T @ y, ord=np.inf) / norm(y)
+    alpha = alpha_max / 10
+
+    dual_init = y / norm(y) if with_dual_init else None
+
+    w, _, _ = PDCD_WS(dual_init=dual_init).solve(X, y, SqrtQuadratic(), L1(alpha))
     clf = SqrtLasso(alpha=alpha, tol=1e-12).fit(X, y)
     w, _, _ = _chambolle_pock_sqrt(X, y, alpha, max_iter=1000)
     np.testing.assert_allclose(clf.coef_, w)

--- a/skglm/experimental/tests/test_sqrt_lasso.py
+++ b/skglm/experimental/tests/test_sqrt_lasso.py
@@ -36,7 +36,7 @@ def test_vs_statsmodels():
     # fit statsmodels on path
     for i in range(n_alphas):
         alpha = alphas[i]
-        # statsmodel fits: ||y - Xw||_2 + alpha* ||w||_1 / sqrt(n_samples)
+        # statsmodels solves: ||y - Xw||_2 + alpha * ||w||_1 / sqrt(n_samples)
         model = linear_model.OLS(y, X)
         model = model.fit_regularized(method='sqrt_lasso', L1_wt=1.,
                                       alpha=np.sqrt(n_samples) * alpha)


### PR DESCRIPTION
This adds a PDCD with working sets solver. In particular, it extends `skglm` to handle problems with non-smooth datafits.

It proceeds as follows:
- [x] implement the solver
- [x] add unittest for Sqrt Lasso
- [ ] perform benchmarks