### PR TITLE
ENH - Automatic support of L2 regulrization in Penalties

### DIFF
--- a/skglm/penalties/base.py
+++ b/skglm/penalties/base.py
@@ -1,3 +1,4 @@
+from numba import float64
 from abc import abstractmethod
 
 
@@ -60,3 +61,73 @@ class BasePenalty():
     @abstractmethod
     def generalized_support(self, w):
         r"""Return a mask which is True for coefficients in the generalized support."""
+
+
+def overload_with_l2(cls):
+    """Decorate a penalty class to add L2 regularization.
+
+    The resulting penalty reads
+
+    .. math::
+
+        "penalty"(w) + "l2"_"regularization" xx ||w||**2 / 2
+
+    Parameters
+    ----------
+    cls: Penalty class
+        The penalty class to be overloaded with L2 regularization.
+
+    Return
+    ------
+    cls: Penalty class
+        Penalty overloaded with L2 regularization.
+    """
+    # keep ref to original methods
+    cls_constructor = cls.__init__
+    cls_prox_1d = cls.prox_1d
+    cls_value = cls.value
+    cls_subdiff_distance = cls. subdiff_distance
+    cls_params_to_dict = cls.params_to_dict
+    cls_get_spec = cls.get_spec
+
+    # implement new methods
+    def __init__(self, *args, l2_regularization=0., **kwargs):
+        cls_constructor(self, *args, **kwargs)
+        self.l2_regularization = l2_regularization
+
+    def prox_1d(self, value, stepsize, j):
+        if self.l2_regularization == 0.:
+            return cls_prox_1d(self, value, stepsize, j)
+
+        scale = 1 + stepsize * self.l2_regularization
+        return cls_prox_1d(self, value / scale, stepsize / scale, j)
+
+    def value(self, w):
+        l2_regularization = self.l2_regularization
+        if l2_regularization == 0.:
+            return cls_value(self, w)
+
+        return cls_value(self, w) + l2_regularization * 0.5 * w ** 2
+
+    def subdiff_distance(self, w, grad, ws):
+        if self.l2_regularization == 0.:
+            return cls_subdiff_distance(self, w, grad, ws)
+
+        return cls_subdiff_distance(self, w, grad + self.l2_regularization * w[ws], ws)
+
+    def get_spec(self):
+        return (('l2_regularization', float64), *cls_get_spec(self))
+
+    def params_to_dict(self):
+        return dict(l2_regularization=self.l2_regularization,
+                    **cls_params_to_dict(self))
+
+    # override methods
+    cls.__init__ = __init__
+    cls.value = value
+    cls.prox_1d = prox_1d
+    cls.subdiff_distance = subdiff_distance
+    cls.get_spec = get_spec
+    cls.params_to_dict = params_to_dict
+
+    return cls

--- a/skglm/penalties/separable.py
+++ b/skglm/penalties/separable.py
@@ -2,7 +2,7 @@ import numpy as np
 from numba import float64
 from numba.types import bool_
 
-from skglm.penalties.base import BasePenalty
+from skglm.penalties.base import BasePenalty, overload_with_l2
 from skglm.utils.prox_funcs import (
     ST, box_proj, prox_05, prox_2_3, prox_SCAD, value_SCAD, prox_MCP, value_MCP)
 
@@ -65,6 +65,12 @@ class L1(BasePenalty):
     def alpha_max(self, gradient0):
         """Return penalization value for which 0 is solution."""
         return np.max(np.abs(gradient0))
+
+
+# To add support of L2 regularization, one needs to decorate the penalty
+@overload_with_l2
+class _TestL1(L1):
+    pass
 
 
 class L1_plus_L2(BasePenalty):


### PR DESCRIPTION
Given a penalty $f: \mathbb{R}^n \rightarrow \mathbb{R}$, that is already implemented in the package,
It is possible to endow it with L2 regularization to get $\Omega = f + \frac{\mu}{2} \lVert \cdot \rVert$

Indeed for a step, $\sigma$ and gradient $\mathrm{grad}$,
the proximal operator and distance to subdifferential can be written using `prox` and `subdiffdistance` of $f$

$$
\mathrm{prox}_{\Omega, \sigma}(x) = \mathrm{prox}_{f, \frac{\sigma}{1 + \sigma \mu}}(\frac{x}{1 + \sigma \mu})
$$


$$
\mathrm{dist}_{\partial \Omega(x)}(-\mathrm{grad}) = \mathrm{dist}_{\partial f(x)}(-\mathrm{grad} - \mu x)
$$


### Implementation

This can be implemented either through inheritance or a class decorator.
This PR provides a POC of the second approach. Hence to add support for L2 regularization, one only needs to decorate the penalty with `overload_with_l2`.


### Help needed

I unittested to the logic and implementation and everything works as expected. However, I'm running into problems when jit-compiling the class as numba doesn't support `*args`, `**kwargs`, which are mandatory to overload the constructor of the penalty.

Any workaround to bypass that?   