### PR TITLE
DOC - Add tutorial for Cox datafit 

### DIFF
--- a/doc/tutorials/cox_datafit.rst
+++ b/doc/tutorials/cox_datafit.rst
@@ -1,0 +1,22 @@
+.. _maths_cox_datafit:
+
+=============================
+Mathematic behind Cox datafit
+=============================
+
+This tutorial presents the mathematics behind Cox datafit using both estimate Breslow and Efron.
+
+
+Problem setup
+=============
+
+Let's consider a typical survival analysis setup with
+
+- :math:`\mathbf{X} \in \mathbb{R}^{n \times p}` is a matrix of :math:`p` predictors and :math:`n` samples :math:`x_i \in \mathbb{R}^p`
+- :math:`y \in \mathbb{R}^n` a vector recording the time of events occurrences
+- :math:`s \in \{ 0, 1 \}^n` a binary vector (observation censorship) where :math:`1` means *event occurred*
+
+where we are interested in estimating a the vector of coefficient :math:`\beta \in \mathbb{R}^p`.
+
+
+

--- a/doc/tutorials/tutorials.rst
+++ b/doc/tutorials/tutorials.rst
@@ -22,3 +22,9 @@ Learn to add a custom penalty by implementing the :math:`\ell_1` penalty.
 -----------------------------------------------------------------
 
 Explore how ``skglm`` fits unpenalized intercept.
+
+
+:ref:`Mathematics behind Cox datafit <maths_cox_datafit>`
+-----------------------------------------------------------------
+
+Get details about Cox datafit equations.


### PR DESCRIPTION
This adds a tutorial in documentation to explain the maths behind the Cox datafit implementation.

fixes #161 