### PR TITLE
MNT - compatibility of ``Cox`` datafit with L2 regularization

### DIFF
--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -646,6 +646,10 @@ class Cox(BaseDatafit):
 
         return out / n_samples
 
+    def gradient(self, X, y, Xw):
+        """Compute gradient of the datafit."""
+        return X.T @ self.raw_grad(y, Xw)
+
     def initialize(self, X, y):
         """Initialize the datafit attributes."""
         tm, s = y

--- a/skglm/tests/test_lbfgs_solver.py
+++ b/skglm/tests/test_lbfgs_solver.py
@@ -1,13 +1,15 @@
+import pytest
 import numpy as np
+import pandas as pd
 
 from skglm.solvers import LBFGS
 from skglm.penalties import L2
-from skglm.datafits import Logistic
+from skglm.datafits import Logistic, Cox
 
 from sklearn.linear_model import LogisticRegression
 
-from skglm.utils.data import make_correlated_data
 from skglm.utils.jit_compilation import compiled_clone
+from skglm.utils.data import make_correlated_data, make_dummy_survival_data
 
 
 def test_lbfgs_L2_logreg():
@@ -34,6 +36,49 @@ def test_lbfgs_L2_logreg():
     np.testing.assert_allclose(
         w, estimator.coef_.flatten(), atol=1e-4
     )
+
+
+@pytest.mark.parametrize("use_efron", [True, False])
+def test_L2_Cox(use_efron):
+    try:
+        from lifelines import CoxPHFitter
+    except ModuleNotFoundError:
+        pytest.xfail(
+            "Testing Cox Estimator requires `lifelines` packages\n"
+            "Run `pip install lifelines`"
+        )
+
+    alpha = 1.
+    n_samples, n_features = 50, 10
+    random_state = 1265
+
+    tm, s, X = make_dummy_survival_data(n_samples, n_features,
+                                        with_ties=use_efron,
+                                        random_state=random_state)
+
+    datafit = compiled_clone(Cox(use_efron))
+    penalty = compiled_clone(L2(alpha))
+
+    datafit.initialize(X, (tm, s))
+    w, *_ = LBFGS().solve(X, (tm, s), datafit, penalty)
+
+    # fit lifeline estimator
+    stacked_tm_s_X = np.hstack((tm[:, None], s[:, None], X))
+    df = pd.DataFrame(stacked_tm_s_X)
+
+    estimator = CoxPHFitter(penalizer=alpha, l1_ratio=0.)
+    estimator.fit(
+        df, duration_col=0, event_col=1,
+        fit_options={"max_steps": 10_000, "precision": 1e-20},
+        show_progress=True,
+    )
+    w_ll = estimator.params_.values
+
+    p_obj_skglm = datafit.value((tm, s), w, X @ w) + penalty.value(w)
+    p_obj_ll = datafit.value((tm, s), w_ll, X @ w_ll) + penalty.value(w_ll)
+
+    # though norm of solution might differ
+    np.testing.assert_allclose(p_obj_skglm, p_obj_ll, atol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For the Cox datafit to be compatible with ``L-BFGS``, a gradient method should be added.

- [x] add gradient method
- [x] unitest against lifelines L2 `CoxPHFitter`