### PR TITLE
ENH - Add ``global_lipschitz`` to ``Cox`` datafit

### DIFF
--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -695,13 +695,13 @@ class Cox(BaseDatafit):
         self.initialize(X_data, y)
 
     def init_global_lipschitz(self, X, y):
-        tm, s = y[:, 0], y[:, 1]  # noqa
+        s = y[:, 1]
 
         n_samples = X.shape[0]
         self.global_lipschitz = s.sum() * norm(X, ord=2) ** 2 / n_samples
 
     def init_global_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
-        tm, s = y[:, 0], y[:, 1]  # noqa
+        s = y[:, 1]
 
         n_samples = s.shape[0]
         norm_X = spectral_norm(X_data, X_indptr, X_indices, n_samples)

--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -599,6 +599,7 @@ class Cox(BaseDatafit):
             ('use_efron', bool_),
             ('T_indptr', int64[:]), ('T_indices', int64[:]),
             ('H_indptr', int64[:]), ('H_indices', int64[:]),
+            ('global_lipschitz', float64),
         )
 
     def params_to_dict(self):
@@ -692,6 +693,20 @@ class Cox(BaseDatafit):
         # `initialize_sparse` and `initialize` have the same implementation
         # small hack to avoid repetitive code: pass in X_data as only its dtype is used
         self.initialize(X_data, y)
+
+    def init_global_lipschitz(self, X, y):
+        tm, s = y[:, 0], y[:, 1]  # noqa
+
+        n_samples = X.shape[0]
+        self.global_lipschitz = s.sum() * norm(X, ord=2) ** 2 / n_samples
+
+    def init_global_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
+        tm, s = y[:, 0], y[:, 1]  # noqa
+
+        n_samples = s.shape[0]
+        norm_X = spectral_norm(X_data, X_indptr, X_indices, n_samples)
+
+        self.global_lipschitz = s.sum() * norm_X ** 2 / n_samples
 
     def _B_dot_vec(self, vec):
         # compute `B @ vec` in O(n) instead of O(n^2)

--- a/skglm/solvers/fista.py
+++ b/skglm/solvers/fista.py
@@ -63,11 +63,19 @@ class FISTA(BaseSolver):
             t_old = t_new
             t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2
             w_old = w.copy()
+
             if X_is_sparse:
-                grad = construct_grad_sparse(
-                    X.data, X.indptr, X.indices, y, z, X @ z, datafit, all_features)
+                if hasattr(datafit, "gradient_sparse"):
+                    grad = datafit.gradient_sparse(
+                        X.data, X.indptr, X.indices, y, X @ z)
+                else:
+                    grad = construct_grad_sparse(
+                        X.data, X.indptr, X.indices, y, z, X @ z, datafit, all_features)
             else:
-                grad = construct_grad(X, y, z, X @ z, datafit, all_features)
+                if hasattr(datafit, "gradient"):
+                    grad = datafit.gradient(X, y, X @ z)
+                else:
+                    grad = construct_grad(X, y, z, X @ z, datafit, all_features)
 
             step = 1 / lipschitz
             z -= step * grad


### PR DESCRIPTION
Following discussion https://github.com/scikit-learn-contrib/skglm/issues/177#issuecomment-1607757655, it happens that the raw Hessian of Cox datafit can be further upper-bounded by

$$
\nabla^2 F(u) \preceq  \frac{\lVert s \rVert_1}{n}  \mathbf{I}_n
$$

which therefore enables to derive the Lipschitz constant

$$
\frac{\lVert s \rVert_1}{n} \lVert \mathbf{X} \rVert^2_2
$$

This adds ``global_lipschitz`` to Cox datafit and thereby allows it to be combined with non-separable penalties, such SLOPE.

-----
fixes #177

also pining @tobias-zehnder, @qklopfenstein-owkin
The implemented [unittest here](https://github.com/Badr-MOUFAD/skglm/blob/cf77084f8a0b9cf2994e102ca37a10f0041b4bdf/skglm/tests/test_estimators.py#L330-L357) provides a handy starter example for fitting Cox + SLOPE
