### PR TITLE
API - Expose a datafit method for solvers to get Lipschitz

### DIFF
--- a/doc/changes/0.4.rst
+++ b/doc/changes/0.4.rst
@@ -3,4 +3,4 @@
 Version 0.4 (in progress)
 ---------------------------
 - Add support for weights and positive coefficients to :ref:`MCPRegression Estimator <skglm.MCPRegression>` (PR: :gh:`184`)
-- Expose a datafit method called by solvers to get Lipschitz. Now on, ``initialize_*`` is meant to initialize internal attributes of the datafit. (PR: :gh:`192`)
+- Move solver specific computations from ``Datafit.initialize()`` to separate ``Datafit`` methods to ease ``Solver`` - ``Datafit`` compatibility check (PR: :gh:`192`)

--- a/doc/changes/0.4.rst
+++ b/doc/changes/0.4.rst
@@ -3,3 +3,4 @@
 Version 0.4 (in progress)
 ---------------------------
 - Add support for weights and positive coefficients to :ref:`MCPRegression Estimator <skglm.MCPRegression>` (PR: :gh:`184`)
+- Expose a datafit method called by solvers to get Lipschitz. Now on, ``initialize_*`` is meant to initialize internal attributes of the datafit. (PR: :gh:`192`)

--- a/skglm/datafits/multi_task.py
+++ b/skglm/datafits/multi_task.py
@@ -40,7 +40,6 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
         return lipschitz
 
     def get_lipschitz_sparse(self, X_data, X_indptr, X_indices, Y):
-        """Pre-computations before fitting on X and Y, when X is sparse."""
         n_samples, n_tasks = Y.shape
         n_features = len(X_indptr) - 1
 

--- a/skglm/datafits/multi_task.py
+++ b/skglm/datafits/multi_task.py
@@ -16,10 +16,6 @@ class QuadraticMultiTask(BaseMultitaskDatafit):
     ----------
     XtY : array, shape (n_features, n_tasks)
         Pre-computed quantity used during the gradient evaluation.
-
-    lipschitz : array, shape (n_features,)
-        The coordinatewise gradient Lipschitz constants. Equal to
-        ``norm(X, axis=0) ** 2 / n_samples``.
     """
 
     def __init__(self):

--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -20,14 +20,6 @@ class Quadratic(BaseDatafit):
         Pre-computed quantity used during the gradient evaluation.
         Equal to ``X.T @ y``.
 
-    lipschitz : array, shape (n_features,)
-        The coordinatewise gradient Lipschitz constants. Equal to
-        ``norm(X, axis=0) ** 2 / n_samples``.
-
-    global_lipschitz : float
-        Global Lipschitz constant. Equal to
-        ``norm(X, ord=2) ** 2 / n_samples``.
-
     Note
     ----
     The class is jit compiled at fit time using Numba compiler.
@@ -130,16 +122,6 @@ class Logistic(BaseDatafit):
 
     .. math:: 1 / n_"samples" \sum_(i=1)^(n_"samples") log(1 + exp(-y_i (Xw)_i))
 
-    Attributes
-    ----------
-    lipschitz : array, shape (n_features,)
-        The coordinatewise gradient Lipschitz constants. Equal to
-        ``norm(X, axis=0) ** 2 / (4 * n_samples)``.
-
-    global_lipschitz : float
-        Global Lipschitz constant. Equal to
-        ``norm(X, ord=2) ** 2 / (4 * n_samples)``.
-
     Note
     ----
     The class is jit compiled at fit time using Numba compiler.
@@ -232,16 +214,6 @@ class QuadraticSVC(BaseDatafit):
 
     .. math:: 1/2 ||(yX)^T w||_2 ^ 2
 
-    Attributes
-    ----------
-    lipschitz : array, shape (n_features,)
-        The coordinatewise gradient Lipschitz constants.
-        Equal to ``norm(yXT, axis=0) ** 2``.
-
-    global_lipschitz : float
-        Global Lipschitz constant. Equal to
-        ``norm(yXT, ord=2) ** 2``.
-
     Note
     ----
     The class is jit compiled at fit time using Numba compiler.
@@ -329,14 +301,6 @@ class Huber(BaseDatafit):
     ----------
     delta : float
         Threshold hyperparameter.
-
-    lipschitz : array, shape (n_features,)
-        The coordinatewise gradient Lipschitz constants. Equal to
-        ``norm(X, axis=0) ** 2 / n_samples``.
-
-    global_lipschitz : float
-        Global Lipschitz constant. Equal to
-        ``norm(X, ord=2) ** 2 / n_samples``.
 
     Note
     ----

--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -122,8 +122,8 @@ class Logistic(BaseDatafit):
 
     .. math:: 1 / n_"samples" \sum_(i=1)^(n_"samples") log(1 + exp(-y_i (Xw)_i))
 
-    Note
-    ----
+    Notes
+    -----
     The class is jit compiled at fit time using Numba compiler.
     This allows for faster computations.
     """
@@ -214,8 +214,8 @@ class QuadraticSVC(BaseDatafit):
 
     .. math:: 1/2 ||(yX)^T w||_2 ^ 2
 
-    Note
-    ----
+    Notes
+    -----
     The class is jit compiled at fit time using Numba compiler.
     This allows for faster computations.
     """

--- a/skglm/solvers/anderson_cd.py
+++ b/skglm/solvers/anderson_cd.py
@@ -75,8 +75,10 @@ class AndersonCD(BaseSolver):
         is_sparse = sparse.issparse(X)
         if is_sparse:
             datafit.initialize_sparse(X.data, X.indptr, X.indices, y)
+            lipschitz = datafit.get_lipschitz_sparse(X.data, X.indptr, X.indices, y)
         else:
             datafit.initialize(X, y)
+            lipschitz = datafit.get_lipschitz(X, y)
 
         if len(w) != n_features + self.fit_intercept:
             if self.fit_intercept:
@@ -102,7 +104,9 @@ class AndersonCD(BaseSolver):
             if self.ws_strategy == "subdiff":
                 opt = penalty.subdiff_distance(w[:n_features], grad, all_feats)
             elif self.ws_strategy == "fixpoint":
-                opt = dist_fix_point(w[:n_features], grad, datafit, penalty, all_feats)
+                opt = dist_fix_point(
+                    w[:n_features], grad, lipschitz, datafit, penalty, all_feats
+                )
 
             if self.fit_intercept:
                 intercept_opt = np.abs(datafit.intercept_update_step(y, Xw))
@@ -141,9 +145,11 @@ class AndersonCD(BaseSolver):
                 if is_sparse:
                     _cd_epoch_sparse(
                         X.data, X.indptr, X.indices, y, w[:n_features], Xw,
-                        datafit, penalty, ws)
+                        lipschitz, datafit, penalty, ws)
                 else:
-                    _cd_epoch(X, y, w[:n_features], Xw, datafit, penalty, ws)
+                    _cd_epoch(
+                        X, y, w[:n_features], Xw, lipschitz, datafit, penalty, ws
+                    )
 
                 # update intercept
                 if self.fit_intercept:
@@ -176,7 +182,8 @@ class AndersonCD(BaseSolver):
                         opt_ws = penalty.subdiff_distance(w[:n_features], grad_ws, ws)
                     elif self.ws_strategy == "fixpoint":
                         opt_ws = dist_fix_point(
-                            w[:n_features], grad_ws, datafit, penalty, ws)
+                            w[:n_features], grad_ws, lipschitz, datafit, penalty, ws
+                        )
 
                     stop_crit_in = np.max(opt_ws)
                     if max(self.verbose - 1, 0):
@@ -260,7 +267,7 @@ class AndersonCD(BaseSolver):
 
 
 @njit
-def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
+def _cd_epoch(X, y, w, Xw, lc, datafit, penalty, ws):
     """Run an epoch of coordinate descent in place.
 
     Parameters
@@ -286,7 +293,6 @@ def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
     ws : array, shape (ws_size,)
         The range of features.
     """
-    lc = datafit.lipschitz
     for j in ws:
         stepsize = 1/lc[j] if lc[j] != 0 else 1000
         Xj = X[:, j]
@@ -299,7 +305,7 @@ def _cd_epoch(X, y, w, Xw, datafit, penalty, ws):
 
 
 @njit
-def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, ws):
+def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, lc, datafit, penalty, ws):
     """Run an epoch of coordinate descent in place for a sparse CSC array.
 
     Parameters
@@ -331,7 +337,6 @@ def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, datafit, penalty, ws
     ws : array, shape (ws_size,)
         The working set.
     """
-    lc = datafit.lipschitz
     for j in ws:
         stepsize = 1/lc[j] if lc[j] != 0 else 1000
 

--- a/skglm/solvers/anderson_cd.py
+++ b/skglm/solvers/anderson_cd.py
@@ -285,7 +285,7 @@ def _cd_epoch(X, y, w, Xw, lc, datafit, penalty, ws):
         Model fit.
 
     lc : array, shape (n_features,)
-        Lipschitz constants of the features.
+        Coordinatewise gradient Lipschitz constants.
 
     datafit : Datafit
         Datafit.
@@ -332,7 +332,7 @@ def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, lc, datafit, penalty
         Model fit.
 
     lc :  array, shape (n_features,)
-        Lipschitz constants of the features.
+        Coordinatewise gradient Lipschitz constants.
 
     datafit : Datafit
         Datafit.

--- a/skglm/solvers/anderson_cd.py
+++ b/skglm/solvers/anderson_cd.py
@@ -284,6 +284,9 @@ def _cd_epoch(X, y, w, Xw, lc, datafit, penalty, ws):
     Xw : array, shape (n_samples,)
         Model fit.
 
+    lc : array, shape (n_features,)
+        Lipschitz constants of the features.
+
     datafit : Datafit
         Datafit.
 
@@ -327,6 +330,9 @@ def _cd_epoch_sparse(X_data, X_indptr, X_indices, y, w, Xw, lc, datafit, penalty
 
     Xw : array, shape (n_samples,)
         Model fit.
+
+    lc :  array, shape (n_features,)
+        Lipschitz constants of the features.
 
     datafit : Datafit
         Datafit.

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -14,6 +14,9 @@ def dist_fix_point(w, grad_ws, lipschitz, datafit, penalty, ws):
     grad_ws : array, shape (ws_size,)
         Gradient restricted to the working set.
 
+    lipschitz :  array, shape (n_features,)
+        Lipschitz constants of the features.
+
     datafit: instance of BaseDatafit
         Datafit.
 

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -15,7 +15,7 @@ def dist_fix_point(w, grad_ws, lipschitz, datafit, penalty, ws):
         Gradient restricted to the working set.
 
     lipschitz :  array, shape (n_features,)
-        Lipschitz constants of the features.
+        Coordinatewise gradient Lipschitz constants.
 
     datafit: instance of BaseDatafit
         Datafit.

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -3,7 +3,7 @@ from numba import njit
 
 
 @njit
-def dist_fix_point(w, grad_ws, datafit, penalty, ws):
+def dist_fix_point(w, grad_ws, lipschitz, datafit, penalty, ws):
     """Compute the violation of the fixed point iterate scheme.
 
     Parameters
@@ -30,7 +30,7 @@ def dist_fix_point(w, grad_ws, datafit, penalty, ws):
     """
     dist_fix_point = np.zeros(ws.shape[0])
     for idx, j in enumerate(ws):
-        lcj = datafit.lipschitz[j]
+        lcj = lipschitz[j]
         if lcj != 0:
             dist_fix_point[idx] = np.abs(
                 w[j] - penalty.prox_1d(w[j] - grad_ws[idx] / lcj, 1. / lcj, j))

--- a/skglm/solvers/fista.py
+++ b/skglm/solvers/fista.py
@@ -48,17 +48,18 @@ class FISTA(BaseSolver):
 
         try:
             if X_is_sparse:
-                datafit.init_global_lipschitz_sparse(X.data, X.indptr, X.indices, y)
+                lipschitz = datafit.get_global_lipschitz_sparse(
+                    X.data, X.indptr, X.indices, y
+                )
             else:
-                datafit.init_global_lipschitz(X, y)
+                lipschitz = datafit.get_global_lipschitz(X, y)
         except AttributeError as e:
             sparse_suffix = '_sparse' if X_is_sparse else ''
 
             raise Exception(
                 "Datafit is not compatible with FISTA solver.\n Datafit must "
-                f"implement `init_global_lipschitz{sparse_suffix}` method") from e
+                f"implement `get_global_lipschitz{sparse_suffix}` method") from e
 
-        lipschitz = datafit.global_lipschitz
         for n_iter in range(self.max_iter):
             t_old = t_new
             t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -246,7 +246,7 @@ def dist_fix_point(W, grad_ws, lipschitz, datafit, penalty, ws):
         Datafit.
 
     lipschitz :  array, shape (n_features,)
-        Lipschitz constants of each bloc.
+        Blockwise gradient Lipschitz constants.
 
     penalty: instance of BasePenalty
         Penalty.
@@ -364,7 +364,7 @@ def _bcd_epoch(X, Y, W, XW, lc, datafit, penalty, ws):
         Model fit.
 
     lc :  array, shape (n_features,)
-        Lipschitz constants of each bloc.
+        Blockwise gradient Lipschitz constants.
 
     datafit : instance of BaseMultiTaskDatafit
         Datafit.
@@ -416,7 +416,7 @@ def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, lc, datafit, penalt
         Model fit.
 
     lc :  array, shape (n_features,)
-        Lipschitz constants of each bloc.
+        Blockwise gradient Lipschitz constants.
 
     datafit : instance of BaseMultiTaskDatafit
         Datafit.

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -245,6 +245,9 @@ def dist_fix_point(W, grad_ws, lipschitz, datafit, penalty, ws):
     datafit: instance of BaseMultiTaskDatafit
         Datafit.
 
+    lipschitz :  array, shape (n_features,)
+        Lipschitz constants of each bloc.
+
     penalty: instance of BasePenalty
         Penalty.
 
@@ -360,6 +363,10 @@ def _bcd_epoch(X, Y, W, XW, lc, datafit, penalty, ws):
     XW : array, shape (n_samples, n_tasks)
         Model fit.
 
+    lc :  array, shape (n_features,)
+        Lipschitz constants of each bloc.
+
+
     datafit : instance of BaseMultiTaskDatafit
         Datafit.
 
@@ -408,6 +415,9 @@ def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, lc, datafit, penalt
 
     XW : array, shape (n_samples, n_tasks)
         Model fit.
+
+    lc :  array, shape (n_features,)
+        Lipschitz constants of each bloc.
 
     datafit : instance of BaseMultiTaskDatafit
         Datafit.

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -51,8 +51,10 @@ class MultiTaskBCD(BaseSolver):
         is_sparse = sparse.issparse(X)
         if is_sparse:
             datafit.initialize_sparse(X.data, X.indptr, X.indices, Y)
+            lipschitz = datafit.get_lipschitz_sparse(X.data, X.indptr, X.indices, Y)
         else:
             datafit.initialize(X, Y)
+            lipschitz = datafit.get_lipschitz(X, Y)
 
         for t in range(self.max_iter):
             if is_sparse:
@@ -92,10 +94,12 @@ class MultiTaskBCD(BaseSolver):
             for epoch in range(self.max_epochs):
                 if is_sparse:
                     _bcd_epoch_sparse(
-                        X.data, X.indptr, X.indices, Y, W, XW, datafit, penalty,
-                        ws)
+                        X.data, X.indptr, X.indices, Y, W, XW,
+                        lipschitz, datafit, penalty, ws
+                    )
                 else:
-                    _bcd_epoch(X, Y, W, XW, datafit, penalty, ws)
+                    _bcd_epoch(X, Y, W, XW, lipschitz, datafit, penalty, ws)
+
                 # update intercept
                 if self.fit_intercept:
                     intercept_old = W[-1, :].copy()
@@ -146,7 +150,9 @@ class MultiTaskBCD(BaseSolver):
                     if self.ws_strategy == "subdiff":
                         opt_ws = penalty.subdiff_distance(W, grad_ws, ws)
                     elif self.ws_strategy == "fixpoint":
-                        opt_ws = dist_fix_point(W, grad_ws, datafit, penalty, ws)
+                        opt_ws = dist_fix_point(
+                            W, grad_ws, lipschitz, datafit, penalty, ws
+                        )
 
                     stop_crit_in = np.max(opt_ws)
                     if max(self.verbose - 1, 0):
@@ -225,7 +231,7 @@ class MultiTaskBCD(BaseSolver):
 
 
 @njit
-def dist_fix_point(W, grad_ws, datafit, penalty, ws):
+def dist_fix_point(W, grad_ws, lipschitz, datafit, penalty, ws):
     """Compute the violation of the fixed point iterate schema.
 
     Parameters
@@ -252,10 +258,11 @@ def dist_fix_point(W, grad_ws, datafit, penalty, ws):
     """
     dist_fix_point = np.zeros(ws.shape[0])
     for idx, j in enumerate(ws):
-        lcj = datafit.lipschitz[j]
+        lcj = lipschitz[j]
         if lcj:
             dist_fix_point[idx] = norm(
-                W[j] - penalty.prox_1feat(W[j] - grad_ws[idx] / lcj, 1. / lcj, j))
+                W[j] - penalty.prox_1feat(W[j] - grad_ws[idx] / lcj, 1. / lcj, j)
+            )
     return dist_fix_point
 
 
@@ -336,7 +343,7 @@ def construct_grad_sparse(data, indptr, indices, Y, XW, datafit, ws):
 
 
 @njit
-def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
+def _bcd_epoch(X, Y, W, XW, lc, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place.
 
     Parameters
@@ -362,7 +369,6 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
     ws : array, shape (ws_size,)
         The working set.
     """
-    lc = datafit.lipschitz
     n_tasks = Y.shape[1]
     for j in ws:
         if lc[j] == 0.:
@@ -380,7 +386,7 @@ def _bcd_epoch(X, Y, W, XW, datafit, penalty, ws):
 
 
 @njit
-def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, datafit, penalty, ws):
+def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, lc, datafit, penalty, ws):
     """Run an epoch of block coordinate descent in place for a sparse CSC array.
 
     Parameters
@@ -412,7 +418,6 @@ def _bcd_epoch_sparse(X_data, X_indptr, X_indices, Y, W, XW, datafit, penalty, w
     ws : array, shape (ws_size,)
         Features to be updated.
     """
-    lc = datafit.lipschitz
     for j in ws:
         if lc[j] == 0.:
             continue

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -366,7 +366,6 @@ def _bcd_epoch(X, Y, W, XW, lc, datafit, penalty, ws):
     lc :  array, shape (n_features,)
         Lipschitz constants of each bloc.
 
-
     datafit : instance of BaseMultiTaskDatafit
         Datafit.
 


### PR DESCRIPTION
## Context of the PR

As highlighted in #191,
This makes Lipschitz (resp. global Lipschitz) accessible via a method instead of an attribute.
``AndersonCD``, ``FISTA`` will require the datafit to define respectively ``get_lipschitz_*`` and ``get_global_lipschitz_*``

Now on ``initialize_*`` is a method to initialize internal attributes of the datafit (attributes not used by solver) such as ``Xty`` of the ``Quadratic`` datafit.

## Contributions of the PR

- expose a datafit method called by solvers to get Lipschitz constants

### Checks before merging PR

- [x] added documentation for any new feature
- ~[ ] added unittests~
- [x] edited the [what's new](../doc/changes/whats_new.rst)

---
The ``*``  is for ``sparse`` 
