### PR TITLE
DOC - Enable viewing dev and stable versions of package documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
 
         # Add stable documentation
         - run:
-          name: stable_doc
-          command: |
+            name: stable_doc
+            command: |
               set -e
               mkdir -p ~/.ssh
               echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,20 @@ jobs:
                 chmod og= ~/.ssh/config
                 cd doc;
                 pip install ghp-import;
+                make add-stable-doc
                 make install
               fi
+
+        # Add stable documentation
+        - run:
+          name: stable_doc
+          command: |
+              set -e
+              mkdir -p ~/.ssh
+              echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
+              chmod og= ~/.ssh/config
+              cd doc;
+              make add-stable-doc
 
         # Save the outputs
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             command: |
               cd doc;
               make clean;
-              make SPHINXOPTS=-v html-noplot;
+              make SPHINXOPTS=-v html;
               cd ..;
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             command: |
               cd doc;
               make clean;
-              make SPHINXOPTS=-v html;
+              make SPHINXOPTS=-v html-noplot;
               cd ..;
 
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -145,14 +145,14 @@ add-stable-doc:
 	pwd
 	ls
 # switch to GITHUB_PAGES_BRANCH where stable build is located
-	git fetch origin $(GITHUB_PAGES_BRANCH);
-	git checkout $(GITHUB_PAGES_BRANCH);
-	git pull origin $(GITHUB_PAGES_BRANCH);
+	git fetch origin $(GITHUB_PAGES_BRANCH)
+	git checkout $(GITHUB_PAGES_BRANCH)
+	git pull origin $(GITHUB_PAGES_BRANCH)
 # move the content of the stable build to the output dir
 	pwd
 	ls
-    mv ../$(STABLE_DOC_DIR)/ $(OUTPUTDIR);
+	mv ../$(STABLE_DOC_DIR) $(OUTPUTDIR)
 # switch back to main and get to doc directory
-	git checkout main;
+	git checkout main
 	pwd
 	ls

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -153,4 +153,5 @@ add-stable-doc:
     fi
 # switch back to main and get to doc directory
 	git checkout main
+	ls
 	cd $(DOC_DIR)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -143,19 +143,17 @@ install:
 
 .PHONY: add-stable-doc
 add-stable-doc:
-	pwd
-	ls
 	cd ..
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH)
 	git checkout $(GITHUB_PAGES_BRANCH)
 # move the content of the stable build to the output dir
+	pwd
+	ls
 	if [ -d "$(STABLE_DOC_DIR)" ]; then \
 		echo "stable copied"; \
         mv $(STABLE_DOC_DIR)/ $(DOC_DIR)/$(OUTPUTDIR); \
     fi
 # switch back to main and get to doc directory
 	git checkout main
-	pwd
-	ls
 	cd $(DOC_DIR)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -142,17 +142,11 @@ install:
 
 .PHONY: add-stable-doc
 add-stable-doc:
-	pwd
-	ls
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH)
 	git checkout $(GITHUB_PAGES_BRANCH)
 	git pull origin $(GITHUB_PAGES_BRANCH)
 # move the content of the stable build to the output dir
-	pwd
-	ls
 	mv ../$(STABLE_DOC_DIR) $(OUTPUTDIR)
 # switch back to main and get to doc directory
 	git checkout main
-	pwd
-	ls

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,6 +9,8 @@ BUILDDIR      = _build
 
 GITHUB_PAGES_BRANCH = gh-pages
 OUTPUTDIR = _build/html
+DOC_DIR = doc
+STABLE_DOC_DIR = stable
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -136,5 +138,18 @@ coverage:
 
 install:
 	touch $(OUTPUTDIR)/.nojekyll
+
+	cd ..
+# switch to GITHUB_PAGES_BRANCH where stable build is located
+	git fetch origin $(GITHUB_PAGES_BRANCH)
+	git checkout $(GITHUB_PAGES_BRANCH)
+# move the content of the stable build to the output dir
+	if [ -d "$(STABLE_DOC_DIR)" ]; then \
+        mv $(STABLE_DOC_DIR)/ $(DOC_DIR)/$(OUTPUTDIR); \
+    fi
+# switch back to main and get to doc directory
+	git checkout main
+	cd $(DOC_DIR)
+
 	ghp-import -m "Generate Pelican site [ci skip]" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
 	git push origin $(GITHUB_PAGES_BRANCH)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -143,10 +143,17 @@ install:
 
 .PHONY: add-stable-doc
 add-stable-doc:
+	pwd
+	ls
+
 	cd ..
+
+	pwd
+	ls
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH)
 	git checkout $(GITHUB_PAGES_BRANCH)
+	git pull origin $(GITHUB_PAGES_BRANCH)
 # move the content of the stable build to the output dir
 	pwd
 	ls
@@ -156,4 +163,6 @@ add-stable-doc:
     fi
 # switch back to main and get to doc directory
 	git checkout main
+	pwd
+	ls
 	cd $(DOC_DIR)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,6 @@ BUILDDIR      = _build
 
 GITHUB_PAGES_BRANCH = gh-pages
 OUTPUTDIR = _build/html
-DOC_DIR = doc
 STABLE_DOC_DIR = stable
 
 # User-friendly check for sphinx-build
@@ -145,11 +144,6 @@ install:
 add-stable-doc:
 	pwd
 	ls
-
-	cd ..;
-
-	pwd
-	ls
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH);
 	git checkout $(GITHUB_PAGES_BRANCH);
@@ -157,12 +151,8 @@ add-stable-doc:
 # move the content of the stable build to the output dir
 	pwd
 	ls
-	if [ -d "$(STABLE_DOC_DIR)" ]; then \
-		echo "stable copied"; \
-        mv $(STABLE_DOC_DIR)/ $(DOC_DIR)/$(OUTPUTDIR); \
-    fi
+    mv ../$(STABLE_DOC_DIR)/ $(OUTPUTDIR);
 # switch back to main and get to doc directory
 	git checkout main;
 	pwd
 	ls
-	cd $(DOC_DIR);

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -143,15 +143,19 @@ install:
 
 .PHONY: add-stable-doc
 add-stable-doc:
+	pwd
+	ls
 	cd ..
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH)
 	git checkout $(GITHUB_PAGES_BRANCH)
 # move the content of the stable build to the output dir
 	if [ -d "$(STABLE_DOC_DIR)" ]; then \
+		echo "stable copied"; \
         mv $(STABLE_DOC_DIR)/ $(DOC_DIR)/$(OUTPUTDIR); \
     fi
 # switch back to main and get to doc directory
 	git checkout main
+	pwd
 	ls
 	cd $(DOC_DIR)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -138,7 +138,11 @@ coverage:
 
 install:
 	touch $(OUTPUTDIR)/.nojekyll
+	ghp-import -m "Generate Pelican site [ci skip]" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
+	git push origin $(GITHUB_PAGES_BRANCH)
 
+.PHONY: add-stable-doc
+add-stable-doc:
 	cd ..
 # switch to GITHUB_PAGES_BRANCH where stable build is located
 	git fetch origin $(GITHUB_PAGES_BRANCH)
@@ -150,6 +154,3 @@ install:
 # switch back to main and get to doc directory
 	git checkout main
 	cd $(DOC_DIR)
-
-	ghp-import -m "Generate Pelican site [ci skip]" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
-	git push origin $(GITHUB_PAGES_BRANCH)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -146,14 +146,14 @@ add-stable-doc:
 	pwd
 	ls
 
-	cd ..
+	cd ..;
 
 	pwd
 	ls
 # switch to GITHUB_PAGES_BRANCH where stable build is located
-	git fetch origin $(GITHUB_PAGES_BRANCH)
-	git checkout $(GITHUB_PAGES_BRANCH)
-	git pull origin $(GITHUB_PAGES_BRANCH)
+	git fetch origin $(GITHUB_PAGES_BRANCH);
+	git checkout $(GITHUB_PAGES_BRANCH);
+	git pull origin $(GITHUB_PAGES_BRANCH);
 # move the content of the stable build to the output dir
 	pwd
 	ls
@@ -162,7 +162,7 @@ add-stable-doc:
         mv $(STABLE_DOC_DIR)/ $(DOC_DIR)/$(OUTPUTDIR); \
     fi
 # switch back to main and get to doc directory
-	git checkout main
+	git checkout main;
 	pwd
 	ls
-	cd $(DOC_DIR)
+	cd $(DOC_DIR);

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -8,16 +8,15 @@
     align-items: center;
     justify-content: space-between;
 
-    border-bottom: 1px solid var(--color-sidebar-search-border);
-    border-top: 1px solid var(--color-sidebar-search-border);
-
-    padding-top: var(--sidebar-search-input-spacing-vertical);
-    padding-bottom: var(--sidebar-search-input-spacing-vertical);
     padding-left: var(--sidebar-item-spacing-horizontal);
     padding-right: var(--sidebar-item-spacing-horizontal);
+    margin-top: 0px;
 }
 
-.sidebar-version-selected {
+.sidebar-version-selected>* {
+    display: flex;
+    align-items: center;
+    padding: 0.25em;
     border-radius: 0.25rem;
     background-color: #ff7f0e;
     color: white;

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -1,0 +1,25 @@
+.announcement {
+    background-color: #1f77b4;
+}
+
+.sidebar-version {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+
+    border-bottom: 1px solid var(--color-sidebar-search-border);
+    border-top: 1px solid var(--color-sidebar-search-border);
+
+    padding-top: var(--sidebar-search-input-spacing-vertical);
+    padding-bottom: var(--sidebar-search-input-spacing-vertical);
+    padding-left: var(--sidebar-item-spacing-horizontal);
+    padding-right: var(--sidebar-item-spacing-horizontal);
+}
+
+.sidebar-version-selected {
+    border-radius: 0.25rem;
+    background-color: #ff7f0e;
+    color: white;
+    pointer-events: none;
+}

--- a/doc/_templates/sidebar/version_toggler.html
+++ b/doc/_templates/sidebar/version_toggler.html
@@ -1,0 +1,16 @@
+<div class="sidebar-tree sidebar-version">
+   <div style="color: #767676;">Version</div>
+
+   <div>
+      <span>
+         <a style="padding: 0.25em; text-decoration: none;"
+            class="{{ 'sidebar-version-selected' if is_stable_version else '' }}" href="stable/index.html">
+            Stable
+         </a>
+
+         <a style="padding: 0.25em; text-decoration: none;"
+            class="{{ '' if is_stable_version else 'sidebar-version-selected' }}" href="index.html">
+            Dev
+         </a>
+   </div>
+</div>

--- a/doc/_templates/sidebar/version_toggler.html
+++ b/doc/_templates/sidebar/version_toggler.html
@@ -4,12 +4,12 @@
    <div>
       <span>
          <a style="padding: 0.25em; text-decoration: none;"
-            class="{{ 'sidebar-version-selected' if is_stable_version else '' }}" href="stable/index.html">
+            class="{{ 'sidebar-version-selected' if is_stable_doc else '' }}" href="stable/index.html">
             Stable
          </a>
 
          <a style="padding: 0.25em; text-decoration: none;"
-            class="{{ '' if is_stable_version else 'sidebar-version-selected' }}" href="index.html">
+            class="{{ '' if is_stable_doc else 'sidebar-version-selected' }}" href="../index.html">
             Dev
          </a>
    </div>

--- a/doc/_templates/sidebar/version_toggler.html
+++ b/doc/_templates/sidebar/version_toggler.html
@@ -1,16 +1,17 @@
 <div class="sidebar-tree sidebar-version">
-   <div style="color: #767676;">Version</div>
+   <span style="color: #767676;">Version</span>
 
-   <div>
-      <span>
-         <a style="padding: 0.25em; text-decoration: none;"
-            class="{{ 'sidebar-version-selected' if is_stable_doc else '' }}" href="stable/index.html">
+   <div style="display: flex; align-items: center; gap: 0.25em;">
+      <span class="{{ 'sidebar-version-selected' if is_stable_doc else '' }}">
+         <a style=" text-decoration: none;" href="stable/index.html">
             Stable
          </a>
+      </span>
 
-         <a style="padding: 0.25em; text-decoration: none;"
-            class="{{ '' if is_stable_doc else 'sidebar-version-selected' }}" href="../index.html">
+      <span class="{{ '' if is_stable_doc else 'sidebar-version-selected' }}">
+         <a style="text-decoration: none;" href="../index.html">
             Dev
          </a>
+      </span>
    </div>
 </div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,7 +251,7 @@ html_sidebars = {
         "sidebar/brand.html",
         "sidebar/search.html",
         "sidebar/navigation.html",
-        "sidebar/version.html",
+        "sidebar/version_toggler.html",
     ]
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,6 +66,9 @@ extensions = [
     # custom ext, see ./sphinxext/gh_substitutions.py
 ]
 
+# TODO comment this variable
+is_stable_doc = False
+
 myst_enable_extensions = [
     "dollarmath",
     "amsmath"
@@ -75,6 +78,8 @@ autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
+
+html_css_files = ["style.css"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -208,7 +213,7 @@ copybutton_prompt_is_regexp = True
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = f"skglm {version} documentation"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -241,7 +246,30 @@ html_favicon = "_static/images/logo.svg"
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/navigation.html",
+        "sidebar/version.html",
+    ]
+}
+
+# TODO write a comment
+html_context = {
+    "is_stable_doc": is_stable_doc
+}
+
+# TODO write a comment
+if not is_stable_doc:
+    html_theme_options = {
+        "announcement": (
+            "You are viewing the documentation of the dev version of "
+            "<code>skglm</code> which contains WIP features. "
+            "View <a href='#'>stable version</a>."
+        )
+    }
+
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -266,7 +266,7 @@ if not is_stable_doc:
         "announcement": (
             "You are viewing the documentation of the dev version of "
             "<code>skglm</code> which contains WIP features. "
-            "View <a href='#'>stable version</a>."
+            "View <a href='stable/index.html'>stable version</a>."
         )
     }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,7 @@ extensions = [
     # custom ext, see ./sphinxext/gh_substitutions.py
 ]
 
-# TODO comment this variable
+# set it to True to build a stable version of the documentation
 is_stable_doc = False
 
 myst_enable_extensions = [
@@ -251,16 +251,18 @@ html_sidebars = {
         "sidebar/brand.html",
         "sidebar/search.html",
         "sidebar/navigation.html",
-        "sidebar/version_toggler.html",
+        "sidebar/version_toggler.html",  # version toggler template
     ]
 }
 
-# TODO write a comment
+# these variables will be available in the sphinx templates
 html_context = {
     "is_stable_doc": is_stable_doc
 }
 
-# TODO write a comment
+
+# when it's the dev version of the documentation, put a banner to warn the user
+# and a link to switch to the dev version of doc
 if not is_stable_doc:
     html_theme_options = {
         "announcement": (

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -249,9 +249,9 @@ html_favicon = "_static/images/logo.svg"
 html_sidebars = {
     "**": [
         "sidebar/brand.html",
+        "sidebar/version_toggler.html",  # version toggler template
         "sidebar/search.html",
         "sidebar/navigation.html",
-        "sidebar/version_toggler.html",  # version toggler template
     ]
 }
 


### PR DESCRIPTION
## Context of the PR

Currently, it is impossible for a user to view the documentation of the stable version 0.3.
As we keep updating the package (new features, bugs, ...) the dev version of the doc diverges from the stable one.

A brief preview of this PR contribution
  
![preview](https://github.com/scikit-learn-contrib/skglm/assets/65614794/af278de8-fc85-4df6-9a3b-7cd9aaa11f54)


Close #203 

## Contributions of the PR

- add a version toggler to switch between the dev and stable versions of the package documentation


### Checks before merging PR

- ~[ ] added documentation for any new feature~
- ~[ ] added unittests~
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst)~
