### PR TITLE
FEAT - Add ``WeightedGroupL2_plus_L1`` penalty

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -45,6 +45,7 @@ Penalties
    PositiveConstraint
    WeightedL1
    WeightedGroupL2
+   WeightedGroupL2_Plus_L1
    WeightedMCPenalty
    SCAD
    BlockSCAD

--- a/skglm/penalties/__init__.py
+++ b/skglm/penalties/__init__.py
@@ -4,7 +4,7 @@ from .separable import (
     WeightedL1, IndicatorBox, PositiveConstraint, LogSumPenalty
 )
 from .block_separable import (
-    L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2
+    L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2, WeightedGroupL2_Plus_L1
 )
 
 from .non_separable import SLOPE
@@ -14,5 +14,5 @@ __all__ = [
     BasePenalty,
     L1_plus_L2, L0_5, L1, L2, L2_3, MCPenalty, WeightedMCPenalty, SCAD, WeightedL1,
     IndicatorBox, PositiveConstraint, L2_05, L2_1, BlockMCPenalty, BlockSCAD,
-    WeightedGroupL2, SLOPE, LogSumPenalty
+    WeightedGroupL2, WeightedGroupL2_Plus_L1, SLOPE, LogSumPenalty
 ]

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -358,7 +358,7 @@ class WeightedGroupL2_Plus_L1(BasePenalty):
         The regularization parameter.
 
     tau : float
-        The mixing parameter between the weighted group L2 and L1 penalties.
+        The mixing parameter of the weighted group L2 and L1 penalties.
         It must be ``0 <= tau < 1``. When ``tau=0``, the penalty is equivalent
         to ``WeightedGroupL2``.
 


### PR DESCRIPTION
## Context of the PR

This PR adds a sparse weighted group L2 penalty enabling for instance fitting a sparse group Lasso estimator. 

Closes #198

## Contributions of the PR

- add ``WeightedGroupL2_plus_L1`` penalty


### Checks before merging PR

- [x] added documentation for any new feature
- [ ] added unittests
- [ ] edited the [what's new](../doc/changes/whats_new.rst)
