### PR TITLE
FIX - Upload documentation only when merging to ``main``

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,12 @@ jobs:
 
         # upload to gh-pages
         - run:
-          name: deploy
-          command: |
-            if [[ ${CIRCLE_BRANCH} == "main" ]]; then
-              pip install ghp-import;
-              make install
-            fi
+            name: deploy
+            command: |
+              if [[ ${CIRCLE_BRANCH} == "main" ]]; then
+                pip install ghp-import;
+                make install
+              fi
 
 
         # Save the outputs


### PR DESCRIPTION
## Context of the PR

Follow up on #206,
In Circleci jobs, the last instructions aren't meant to run if we merge to ``main``
https://github.com/scikit-learn-contrib/skglm/blob/c67a88532a0e062bfde8d727de44f55f4dd4baff/.circleci/config.yml#L85-L94
since these are already performed in the ``Deploy`` step.

Therefore the CI fails (although everything is fine)


## Contributions of the PR

- upload documentation to ``gh-pages`` if the branch is ``main``


### Checks before merging PR

- ~[ ] added documentation for any new feature~
- ~[ ] added unittests~
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst)~
