### PR TITLE
DOC - Hide table of contents in documentation home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -79,11 +79,13 @@ You are free to use it and if you do so, please cite
         year      = {2022},
 
 
-Explore the documentation
--------------------------
+.. it mandatory to keep the toctree here although it doesn't show up in the page
+.. when adding/modifying pages, don't forget to update the toctree
 
 .. toctree::
     :maxdepth: 1
+    :hidden:
+    :includehidden:
 
     getting_started.rst
     tutorials/tutorials.rst


### PR DESCRIPTION
## Context of the PR

The home page of the documentation has a table of contents at the bottom of the page.
This makes it redundant as it appears on the page's sidebar. 


## Contributions of the PR

- Hide the documentation toctree


### Checks before merging PR

- ~[ ] added documentation for any new feature~
- ~[ ] added unittests~
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst)(if applicable)~

-----
PS. Also this PR is a sanity check for dev/stable doc deployment
