### PR TITLE
DOC - Fix link to stable documentation

### DIFF
--- a/doc/_templates/sidebar/version_toggler.html
+++ b/doc/_templates/sidebar/version_toggler.html
@@ -3,13 +3,13 @@
 
    <div style="display: flex; align-items: center; gap: 0.25em;">
       <span class="{{ 'sidebar-version-selected' if is_stable_doc else '' }}">
-         <a style=" text-decoration: none;" href="/stable/index.html">
+         <a style=" text-decoration: none;" href="https://contrib.scikit-learn.org/skglm/stable/index.html">
             Stable
          </a>
       </span>
 
       <span class="{{ '' if is_stable_doc else 'sidebar-version-selected' }}">
-         <a style="text-decoration: none;" href="/index.html">
+         <a style="text-decoration: none;" href="https://contrib.scikit-learn.org/skglm/">
             Dev
          </a>
       </span>

--- a/doc/_templates/sidebar/version_toggler.html
+++ b/doc/_templates/sidebar/version_toggler.html
@@ -3,13 +3,13 @@
 
    <div style="display: flex; align-items: center; gap: 0.25em;">
       <span class="{{ 'sidebar-version-selected' if is_stable_doc else '' }}">
-         <a style=" text-decoration: none;" href="stable/index.html">
+         <a style=" text-decoration: none;" href="/stable/index.html">
             Stable
          </a>
       </span>
 
       <span class="{{ '' if is_stable_doc else 'sidebar-version-selected' }}">
-         <a style="text-decoration: none;" href="../index.html">
+         <a style="text-decoration: none;" href="/index.html">
             Dev
          </a>
       </span>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,7 +269,8 @@ if not is_stable_doc:
         "announcement": (
             "You are viewing the documentation of the dev version of "
             "<code>skglm</code> which contains WIP features. "
-            "View <a href='stable/index.html'>stable version</a>."
+            "View <a href='https://contrib.scikit-learn.org/skglm/stable/index.html'>"
+            "stable version</a>."
         )
     }
 


### PR DESCRIPTION
## Context of the PR

The links used to get to the `stable` and `dev` documentation are relative, hence they break when used in a location other than home.

## Contributions of the PR

- Use absolute links


### Checks before merging PR

- ~[ ] added documentation for any new feature~
- ~[ ] added unittests~
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst)(if applicable)~
