### PR TITLE
FIX - computation of ``subdiff_distance`` in ``WeightedGroupL2`` penalty

### DIFF
--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -135,5 +135,27 @@ and thus, combined with Equations :eq:`prox_projection_nn_Sc` and :eq:`prox_proj
     .
 
 
+
+Subdifferential of the positive Group Lasso penalty
+===================================================
+
+For the `subdiff_diff` working set strategy, we compute the distance to the subdifferential of
+the $\Vert \cdot \Vert + \iota_{\mathbb{R}_+}$ penalty.
+
+If any component is strictly negative, the subdifferential is empty, and the distance is $+ \infty$.
+
+At a non zero point with strictly positive entries, the penalty is differentiable with only subgradient $w_g/\Vert w_g \Vert$.
+
+At 0, the subdifferential is
+.. math::
+
+    \lambda \partial \lVert \cdot \lVert_2 + \partial \delta_{\mathbb{R}_{+}^g} = \lambda \mathcal{B}_2 + \mathbb{R}^{-}_g
+
+Let $v \in \mathbb{R}^g$, and $\hat v$ its projection onto $\lambda \mathcal{B}_2 + \mathbb{R}^{-}_g$.
+It is clear that for $j$ such that $v_j \leq 0$, $v_j = \hat v_j$.
+Then, the entries in $\mathcal{S} = \{j : v_j > 0}$ are simply given by the projection of $v_\mathcal{S}$ onto $\lambda \mathcal{B}_2$.
+
+
 References
 ==========
+

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -16,7 +16,7 @@ Let
     g:x \mapsto \norm{x}_2
     ,
 
-then
+then its Fenchel-Legendre conjugate is
 
 .. math::
     :label: fenchel
@@ -42,7 +42,7 @@ Using the Moreau decomposition, Equations :eq:`fenchel` and :eq:`prox_projection
     \text{prox}_{\lambda g}(x)
     =
     x
-    - \lambda \text{prox}_{\lambda g^\star}(x/\lambda)
+    - \lambda \text{prox}_{g^\star/\lambda }(x/\lambda)
 
 .. math::
 
@@ -112,7 +112,7 @@ As before, using the Moreau decomposition and Equation :eq:`fenchel_nn` yields
     \text{prox}_{\lambda h}(x)
     =
     x
-    - \lambda \text{prox}_{\lambda h^\star}(x/\lambda)
+    - \lambda \text{prox}_{h^\star / \lambda }(x/\lambda)
 
 .. math::
 

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -139,21 +139,40 @@ and thus, combined with Equations :eq:`prox_projection_nn_Sc` and :eq:`prox_proj
 Subdifferential of the positive Group Lasso penalty
 ===================================================
 
-For the ```subdiff_diff``` working set strategy, we compute the (distance to the) subdifferential of
-the :math:`|| \cdot || + \iota_{\geq 0}`` penalty at a point :math:`w`.
-Because the penalty is separable over group, we consider a block of variables, in :math:`\mathbb{R}^g`.
+For the ``subdiff_diff`` working set strategy, we compute the distance :math:`D(v)` for some :math:`v` to the subdifferential of the :math:`h` penalty at a point :math:`w`.
+Since the penalty is group-separable, we consider a block of variables, in :math:`\mathbb{R}^g`.
+
+Case :math:`w` has a strictly negative coordinate
+-------------------------------------------------
 
 If any component of :math:`w` is strictly negative, the subdifferential is empty, and the distance is :math:`+ \infty`.
 
-At a non zero point with strictly positive entries, the penalty is differentiable with only subgradient :math:`w/ {|| w ||}`.
+.. math::
+
+    D(v) = + \infty, \quad \forall v \in \mathbb{R}^g
+    .
+
+
+Case :math:`w` is a strictly positive
+-------------------------------------
+
+At a non zero point with strictly positive entries, the penalty is differentiable hence its subgradient is the singleton :math:`w / {|| w ||}`.
+
+.. math::
+
+    D(v) = || v - w / {|| w ||} ||, \quad \forall v \in \mathbb{R}^g
+    .
+
+Case :math:`w = 0`
+-------------------------------------
 
 At :math:`w = 0`, the subdifferential is:
 
 .. math::
 
-    \lambda \partial || \cdot ||_2 + \partial \iota_{\geq 0} = \lambda \mathcal{B}_2 + \mathbb{R}_-^g
+    \lambda \partial || \cdot ||_2 + \partial \iota_{x \geq 0} = \lambda \mathcal{B}_2 + \mathbb{R}_-^g
 
-where :math:`\mathcal{B}_2`` is the unit ball.
+where :math:`\mathcal{B}_2` is the unit ball.
 
 Let :math:`v \in \mathbb{R}^g`, and :math:`\hat v`` its projection onto :math:`\lambda \mathcal{B}_2 + \mathbb{R}_-^g`.
 It is clear that for :math:`j` such that :math:`v_j \leq 0`, :math:`v_j = \hat v_j`.
@@ -162,4 +181,3 @@ Then, the entries in :math:`\mathcal{S} = \{j : v_j > 0}` are simply given by th
 
 References
 ==========
-

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -139,24 +139,25 @@ and thus, combined with Equations :eq:`prox_projection_nn_Sc` and :eq:`prox_proj
 Subdifferential of the positive Group Lasso penalty
 ===================================================
 
-For the `subdiff_diff` working set strategy, we compute the distance to the subdifferential of
-the $\Vert \cdot \Vert + \iota_{\mathbb{R}_+}$ penalty.
+For the ```subdiff_diff``` working set strategy, we compute the (distance to the) subdifferential of
+the :math:`|| \cdot || + \iota_{\geq 0}`` penalty at a point :math:`w`.
+Because the penalty is separable over group, we consider a block of variables, in :math:`\mathbb{R}^g`.
 
-If any component is strictly negative, the subdifferential is empty, and the distance is $+ \infty$.
+If any component of :math:`w` is strictly negative, the subdifferential is empty, and the distance is :math:`+ \infty`.
 
-At a non zero point with strictly positive entries, the penalty is differentiable with only subgradient $w_g/\Vert w_g \Vert$.
+At a non zero point with strictly positive entries, the penalty is differentiable with only subgradient :math:`w/ {|| w ||}`.
 
-At 0, the subdifferential is
+At :math:`w = 0`, the subdifferential is:
 
 .. math::
 
-    \lambda \partial \Vert \cdot \Vert_2 + \partial \delta_{\mathbb{R}_{+}^g} = \lambda B_2 + \mathbb{R}^{-}_g
+    \lambda \partial || \cdot ||_2 + \partial \iota_{\geq 0} = \lambda \mathcal{B}_2 + \mathbb{R}_-^g
 
-where :math:`B_2`` is the unit ball.
+where :math:`\mathcal{B}_2`` is the unit ball.
 
-Let :math:`v \in \mathbb{R}^g`, and :math:`\hat v`` its projection onto :math:`\lambda B_2 + \mathbb{R}^{-}_g`.
+Let :math:`v \in \mathbb{R}^g`, and :math:`\hat v`` its projection onto :math:`\lambda \mathcal{B}_2 + \mathbb{R}_-^g`.
 It is clear that for :math:`j` such that :math:`v_j \leq 0`, :math:`v_j = \hat v_j`.
-Then, the entries in :math:`\mathcal{S} = \{j : v_j > 0}` are simply given by the projection of :math:`v_\mathcal{S}` onto :math:`\lambda B_2`.
+Then, the entries in :math:`\mathcal{S} = \{j : v_j > 0}` are simply given by the projection of :math:`v_\mathcal{S}` onto :math:`\lambda \mathcal{B}_2`.
 
 
 References

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -1,10 +1,10 @@
 .. _prox_nn_group_lasso:
 
-====================================================
-Details on the proximity operator of the group Lasso
-====================================================
+===================================
+Details on the Positive Group Lasso
+===================================
 
-This tutorial presents how to derive the proximity operator of the :math:`l_2`-penalty, and the :math:`l_2`-penalty with nonnegative constraints.
+This tutorial presents how to derive the proximity operator and subdifferential of the :math:`l_2`-penalty, and the :math:`l_2`-penalty with nonnegative constraints.
 
 
 Proximity operator of the group Lasso
@@ -147,13 +147,16 @@ If any component is strictly negative, the subdifferential is empty, and the dis
 At a non zero point with strictly positive entries, the penalty is differentiable with only subgradient $w_g/\Vert w_g \Vert$.
 
 At 0, the subdifferential is
+
 .. math::
 
-    \lambda \partial \lVert \cdot \lVert_2 + \partial \delta_{\mathbb{R}_{+}^g} = \lambda \mathcal{B}_2 + \mathbb{R}^{-}_g
+    \lambda \partial \Vert \cdot \Vert_2 + \partial \delta_{\mathbb{R}_{+}^g} = \lambda B_2 + \mathbb{R}^{-}_g
 
-Let $v \in \mathbb{R}^g$, and $\hat v$ its projection onto $\lambda \mathcal{B}_2 + \mathbb{R}^{-}_g$.
-It is clear that for $j$ such that $v_j \leq 0$, $v_j = \hat v_j$.
-Then, the entries in $\mathcal{S} = \{j : v_j > 0}$ are simply given by the projection of $v_\mathcal{S}$ onto $\lambda \mathcal{B}_2$.
+where :math:`B_2`` is the unit ball.
+
+Let :math:`v \in \mathbb{R}^g`, and :math:`\hat v`` its projection onto :math:`\lambda B_2 + \mathbb{R}^{-}_g`.
+It is clear that for :math:`j` such that :math:`v_j \leq 0`, :math:`v_j = \hat v_j`.
+Then, the entries in :math:`\mathcal{S} = \{j : v_j > 0}` are simply given by the projection of :math:`v_\mathcal{S}` onto :math:`\lambda B_2`.
 
 
 References

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -153,8 +153,8 @@ If any component of :math:`w` is strictly negative, the subdifferential is empty
     .
 
 
-Case :math:`w` is a strictly positive
--------------------------------------
+Case :math:`w` is strictly positive
+-----------------------------------
 
 At a non zero point with strictly positive entries, the penalty is differentiable hence its subgradient is the singleton :math:`w / {|| w ||}`.
 
@@ -182,17 +182,17 @@ Therefore, the distance to the subdifferential writes
     D(v) = \min_{u \in \lambda \mathcal{B}_2, n \in \mathbb{R}_{-}^g} \ || u + n - v ||
     .
 
-Computing the :math:`\min` over :math:`\mathbb{R}_{-}^g` then :math:`\lambda \mathcal{B}_2`, thanks to [`1 <https://math.stackexchange.com/questions/2885223/can-i-switch-the-order-of-taking-minimums>`_], yields
+Minimizing over :math:`n` then over :math:`u`, thanks to [`1 <https://math.stackexchange.com/a/2887332/167258>`_], yields
 
 .. math::
 
     D(v) = \max(0, ||v^+|| - \lambda)
     ,
 
-Where :math:`v^+` are the positive coordinates of :math:`v`.
+Where :math:`v^+` is :math:`v` restricted to its positive coordinates.
 
 
 References
 ==========
 
-[1] Refer to the answer in `<https://math.stackexchange.com/questions/2885223/can-i-switch-the-order-of-taking-minimums>`_
+[1] `<https://math.stackexchange.com/a/2887332/167258>`_

--- a/doc/tutorials/prox_nn_group_lasso.rst
+++ b/doc/tutorials/prox_nn_group_lasso.rst
@@ -70,7 +70,6 @@ A similar formula can be derived for the group Lasso with nonnegative constraint
 Proximity operator of the group Lasso with positivity constraints
 =================================================================
 
-
 Let
 
 .. math::
@@ -136,6 +135,7 @@ and thus, combined with Equations :eq:`prox_projection_nn_Sc` and :eq:`prox_proj
 
 
 
+.. _subdiff_positive_group_lasso:
 Subdifferential of the positive Group Lasso penalty
 ===================================================
 
@@ -164,20 +164,35 @@ At a non zero point with strictly positive entries, the penalty is differentiabl
     .
 
 Case :math:`w = 0`
--------------------------------------
+------------------
 
 At :math:`w = 0`, the subdifferential is:
 
 .. math::
 
     \lambda \partial || \cdot ||_2 + \partial \iota_{x \geq 0} = \lambda \mathcal{B}_2 + \mathbb{R}_-^g
+    ,
 
 where :math:`\mathcal{B}_2` is the unit ball.
 
-Let :math:`v \in \mathbb{R}^g`, and :math:`\hat v`` its projection onto :math:`\lambda \mathcal{B}_2 + \mathbb{R}_-^g`.
-It is clear that for :math:`j` such that :math:`v_j \leq 0`, :math:`v_j = \hat v_j`.
-Then, the entries in :math:`\mathcal{S} = \{j : v_j > 0}` are simply given by the projection of :math:`v_\mathcal{S}` onto :math:`\lambda \mathcal{B}_2`.
+Therefore, the distance to the subdifferential writes
+
+.. math::
+
+    D(v) = \min_{u \in \lambda \mathcal{B}_2, n \in \mathbb{R}_{-}^g} \ || u + n - v ||
+    .
+
+Computing the :math:`\min` over :math:`\mathbb{R}_{-}^g` then :math:`\lambda \mathcal{B}_2`, thanks to [`1 <https://math.stackexchange.com/questions/2885223/can-i-switch-the-order-of-taking-minimums>`_], yields
+
+.. math::
+
+    D(v) = \max(0, ||v^+|| - \lambda)
+    ,
+
+Where :math:`v^+` are the positive coordinates of :math:`v`.
 
 
 References
 ==========
+
+[1] Refer to the answer in `<https://math.stackexchange.com/questions/2885223/can-i-switch-the-order-of-taking-minimums>`_

--- a/doc/tutorials/tutorials.rst
+++ b/doc/tutorials/tutorials.rst
@@ -32,4 +32,4 @@ Get details about Cox datafit equations.
 :ref:`Details on the group Lasso <prox_nn_group_lasso>`
 -----------------------------------------------------------------
 
-Get details about how to compute the prox of the group Lasso with and without nonnegativity constraints.
+Mathematical details about the group Lasso, in particular with nonnegativity constraints.

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -317,7 +317,7 @@ class WeightedGroupL2(BasePenalty):
 
         Refer to :ref:`subdiff_positive_group_lasso` for details of the derivation.
 
-        Note
+        Note:
         ----
         ``grad_ws`` is a stacked array of gradients ``[grad_ws_1, grad_ws_2, ...]``.
         """

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -326,7 +326,7 @@ class WeightedGroupL2(BasePenalty):
                 scores[idx] = np.inf
             elif self.positive and norm_w_g == 0:
                 # distance of -norm(neg_grad_g) to weights[g] * [-alpha, alpha]
-                neg_grad_g = np.where(grad_g < 0., grad_g, 0.)
+                neg_grad_g = grad_g[grad_g < 0.]
                 scores[idx] = max(0, norm(neg_grad_g) - self.alpha * weights[g])
             elif (not self.positive) and norm_w_g == 0:
                 # distance of -norm(grad_g) to weights[g] * [-alpha, alpha]

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -240,6 +240,16 @@ class WeightedGroupL2(BasePenalty):
 
     with :math:`w_{[g]}` being the coefficients of the g-th group.
 
+    When ``positive=True``, it reads
+
+    .. math::
+        sum_{g=1}^{n_"groups"} "weights"_g xx ||w_{[g]}|| + i_{w_{[g]} \geq 0}
+
+    Where :math:`i_{w_{[g]} \geq 0}` is the indicator function of the positive orthant.
+
+    Refer to :ref:`prox_nn_group_lasso` for details on the derivation of the proximal
+    operator and the distance to subdifferential.
+
     Attributes
     ----------
     alpha : float
@@ -305,8 +315,11 @@ class WeightedGroupL2(BasePenalty):
     def subdiff_distance(self, w, grad_ws, ws):
         """Compute distance to the subdifferential at ``w`` of negative gradient.
 
-        Note: ``grad_ws`` is a stacked array of gradients.
-        ([grad_ws_1, grad_ws_2, ...])
+        Refer to :ref:`subdiff_positive_group_lasso` for details of the derivation.
+
+        Note
+        ----
+        ``grad_ws`` is a stacked array of gradients ``[grad_ws_1, grad_ws_2, ...]``.
         """
         alpha, weights = self.alpha, self.weights
         grp_ptr, grp_indices = self.grp_ptr, self.grp_indices
@@ -322,7 +335,6 @@ class WeightedGroupL2(BasePenalty):
             w_g = w[grp_g_indices]
             norm_w_g = norm(w_g)
 
-            # see the documentation for mathematical details
             if self.positive and np.any(w_g < 0):
                 scores[idx] = np.inf
             elif self.positive and norm_w_g == 0:

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -324,10 +324,11 @@ class WeightedGroupL2(BasePenalty):
 
             if self.positive and np.any(w_g < 0):
                 scores[idx] = np.inf
-            if self.positive and norm_w_g == 0:
-                # distance of -norm(grad_g) to )-infty, alpha * weights[g]]
-                scores[idx] = max(0, - norm(grad_g) - self.alpha * weights[g])
-            if (not self.positive) and norm_w_g == 0:
+            elif self.positive and norm_w_g == 0:
+                # distance of -norm(neg_grad_g) to weights[g] * [-alpha, alpha]
+                neg_grad_g = np.where(grad_g < 0., grad_g, 0.)
+                scores[idx] = max(0, norm(neg_grad_g) - self.alpha * weights[g])
+            elif (not self.positive) and norm_w_g == 0:
                 # distance of -norm(grad_g) to weights[g] * [-alpha, alpha]
                 scores[idx] = max(0, norm(grad_g) - alpha * weights[g])
             else:

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -322,6 +322,7 @@ class WeightedGroupL2(BasePenalty):
             w_g = w[grp_g_indices]
             norm_w_g = norm(w_g)
 
+            # see the documentation for mathematical details
             if self.positive and np.any(w_g < 0):
                 scores[idx] = np.inf
             elif self.positive and norm_w_g == 0:

--- a/skglm/tests/test_group.py
+++ b/skglm/tests/test_group.py
@@ -79,14 +79,14 @@ def test_alpha_max(n_groups, n_features, shuffle):
 @pytest.mark.parametrize('positive', [False, True])
 def test_equivalence_lasso(positive):
     n_samples, n_features = 30, 50
-    rnd = np.random.RandomState(1123)
+    rnd = np.random.RandomState(112)
     X, y, _ = make_correlated_data(n_samples, n_features, random_state=rnd)
 
     grp_indices, grp_ptr = grp_converter(1, n_features)
     weights = abs(rnd.randn(n_features))
 
     alpha_max = norm(X.T @ y / weights, ord=np.inf) / n_samples
-    alpha = alpha_max / 10.
+    alpha = alpha_max / 100.
 
     quad_group = QuadraticGroup(grp_ptr=grp_ptr, grp_indices=grp_indices)
     group_penalty = WeightedGroupL2(

--- a/skglm/utils/prox_funcs.py
+++ b/skglm/utils/prox_funcs.py
@@ -48,7 +48,7 @@ def BST(x, u, positive=False):
     .. math::
         "BST"(x, u)_{S^c} = 0 ,
 
-    the proof can be adapted from [1].
+    the proof can be adapted from [1]; see the details in the documentation.
 
     References
     ----------


### PR DESCRIPTION
## Context of the PR

This fixes the bug reported in issue #197 (thanks for the investigation @tomaszkacprzak)

## Contributions of the PR

- fix computation of `subdiff_distance`
- harden unittest


### Checks before merging PR

- ~[ ] added documentation for any new feature~
- [x] added unittests
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst)~
