### PR TITLE
MNT: change solver quantile regressor sklearn

### DIFF
--- a/skglm/experimental/tests/test_quantile_regression.py
+++ b/skglm/experimental/tests/test_quantile_regression.py
@@ -28,7 +28,8 @@ def test_PDCD_WS(quantile_level):
     clf = QuantileRegressor(
         quantile=quantile_level,
         alpha=alpha/n_samples,
-        fit_intercept=False
+        fit_intercept=False,
+        solver='highs',
     ).fit(X, y)
 
     np.testing.assert_allclose(w, clf.coef_, atol=1e-5)


### PR DESCRIPTION
sklearn raises an error when the version of scipy is > 1.11 and the QuantileRegressor solver is `"interior-point"`