### PR TITLE
FIX ProxNewton solver with fixpoint strategy

### DIFF
--- a/skglm/solvers/anderson_cd.py
+++ b/skglm/solvers/anderson_cd.py
@@ -184,7 +184,7 @@ class AndersonCD(BaseSolver):
                         opt_ws = penalty.subdiff_distance(w[:n_features], grad_ws, ws)
                     elif self.ws_strategy == "fixpoint":
                         opt_ws = dist_fix_point_cd(
-                            w[:n_features], grad_ws, lipschitz, datafit, penalty, ws
+                            w[:n_features], grad_ws, lipschitz[ws], datafit, penalty, ws
                         )
 
                     stop_crit_in = np.max(opt_ws)

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -14,7 +14,7 @@ def dist_fix_point_cd(w, grad_ws, lipschitz_ws, datafit, penalty, ws):
     grad_ws : array, shape (ws_size,)
         Gradient restricted to the working set.
 
-    lipschitz_ws :  array, shape (ws_size,)
+    lipschitz_ws :  array, shape (len(ws),)
         Coordinatewise gradient Lipschitz constants, restricted to working set.
 
     datafit: instance of BaseDatafit
@@ -23,7 +23,7 @@ def dist_fix_point_cd(w, grad_ws, lipschitz_ws, datafit, penalty, ws):
     penalty: instance of BasePenalty
         Penalty.
 
-    ws : array, shape (ws_size,)
+    ws : array, shape (len(ws),)
         The working set.
 
     Returns

--- a/skglm/solvers/common.py
+++ b/skglm/solvers/common.py
@@ -3,7 +3,7 @@ from numba import njit
 
 
 @njit
-def dist_fix_point_cd(w, grad_ws, lipschitz, datafit, penalty, ws):
+def dist_fix_point_cd(w, grad_ws, lipschitz_ws, datafit, penalty, ws):
     """Compute the violation of the fixed point iterate scheme.
 
     Parameters
@@ -14,8 +14,8 @@ def dist_fix_point_cd(w, grad_ws, lipschitz, datafit, penalty, ws):
     grad_ws : array, shape (ws_size,)
         Gradient restricted to the working set.
 
-    lipschitz :  array, shape (n_features,)
-        Coordinatewise gradient Lipschitz constants.
+    lipschitz_ws :  array, shape (ws_size,)
+        Coordinatewise gradient Lipschitz constants, restricted to working set.
 
     datafit: instance of BaseDatafit
         Datafit.
@@ -34,10 +34,10 @@ def dist_fix_point_cd(w, grad_ws, lipschitz, datafit, penalty, ws):
     dist = np.zeros(ws.shape[0], dtype=w.dtype)
 
     for idx, j in enumerate(ws):
-        if lipschitz[j] == 0.:
+        if lipschitz_ws[idx] == 0.:
             continue
 
-        step_j = 1 / lipschitz[j]
+        step_j = 1 / lipschitz_ws[idx]
         dist[idx] = np.abs(
             w[j] - penalty.prox_1d(w[j] - step_j * grad_ws[idx], step_j, j)
         )

--- a/skglm/solvers/multitask_bcd.py
+++ b/skglm/solvers/multitask_bcd.py
@@ -66,7 +66,9 @@ class MultiTaskBCD(BaseSolver):
             if self.ws_strategy == "subdiff":
                 opt = penalty.subdiff_distance(W, grad, all_feats)
             elif self.ws_strategy == "fixpoint":
-                opt = dist_fix_point_bcd(W, grad, datafit, penalty, all_feats)
+                opt = dist_fix_point_bcd(
+                    W, grad, lipschitz, datafit, penalty, all_feats
+                )
             stop_crit = np.max(opt)
             if self.verbose:
                 print(f"Stopping criterion max violation: {stop_crit:.2e}")

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -65,6 +65,9 @@ class ProxNewton(BaseSolver):
         self.verbose = verbose
 
     def solve(self, X, y, datafit, penalty, w_init=None, Xw_init=None):
+        if self.ws_strategy not in ("subdiff", "fixpoint"):
+            raise ValueError("ws_strategy must be `subdiff` or `fixpoint`, "
+                             f"got {self.ws_strategy}.")
         dtype = X.dtype
         n_samples, n_features = X.shape
         fit_intercept = self.fit_intercept

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -256,7 +256,7 @@ def _descent_direction(X, y, w_epoch, Xw_epoch, fit_intercept, grad_ws, datafit,
                 opt = penalty.subdiff_distance(current_w, past_grads, ws)
             elif ws_strategy == "fixpoint":
                 opt = dist_fix_point_cd(
-                    current_w, past_grads, lipschitz, datafit, penalty, ws
+                    current_w, past_grads, lipschitz[ws], datafit, penalty, ws
                 )
             stop_crit = np.max(opt)
 

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -140,6 +140,8 @@ class ProxNewton(BaseSolver):
             # similar to np.argsort()[-ws_size:] but without sorting
             ws = np.argpartition(opt, -ws_size)[-ws_size:]
 
+            print(ws)
+
             grad_ws = grad[ws]
             tol_in = EPS_TOL * stop_crit
 
@@ -470,3 +472,15 @@ def _update_X_delta_w(X_data, X_indptr, X_indices, X_delta_w, diff, j):
     # Compute X_delta_w += diff * X[:, j] in case of X sparse
     for i in range(X_indptr[j], X_indptr[j+1]):
         X_delta_w[X_indices[i]] += diff * X_data[i]
+
+
+@njit
+def compute_lipschitz(X, y, w_epoch, Xw_epoch, datafit, ws):
+    dtype = X.dtype
+    raw_hess = datafit.raw_hessian(y, Xw_epoch)
+
+    lipschitz_ws = np.zeros(len(ws), dtype)
+    for idx, j in enumerate(ws):
+        lipschitz_ws[idx] = raw_hess @ X[:, j] ** 2
+
+    return lipschitz_ws

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -140,7 +140,7 @@ class ProxNewton(BaseSolver):
             # similar to np.argsort()[-ws_size:] but without sorting
             ws = np.argpartition(opt, -ws_size)[-ws_size:]
 
-            print(ws)
+            print(f"Iter {t:<3}: {ws}")
 
             grad_ws = grad[ws]
             tol_in = EPS_TOL * stop_crit

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -140,8 +140,6 @@ class ProxNewton(BaseSolver):
             # similar to np.argsort()[-ws_size:] but without sorting
             ws = np.argpartition(opt, -ws_size)[-ws_size:]
 
-            print(f"Iter {t:<3}: {ws}")
-
             grad_ws = grad[ws]
             tol_in = EPS_TOL * stop_crit
 

--- a/skglm/solvers/prox_newton.py
+++ b/skglm/solvers/prox_newton.py
@@ -472,15 +472,3 @@ def _update_X_delta_w(X_data, X_indptr, X_indices, X_delta_w, diff, j):
     # Compute X_delta_w += diff * X[:, j] in case of X sparse
     for i in range(X_indptr[j], X_indptr[j+1]):
         X_delta_w[X_indices[i]] += diff * X_data[i]
-
-
-@njit
-def compute_lipschitz(X, y, w_epoch, Xw_epoch, datafit, ws):
-    dtype = X.dtype
-    raw_hess = datafit.raw_hessian(y, Xw_epoch)
-
-    lipschitz_ws = np.zeros(len(ws), dtype)
-    for idx, j in enumerate(ws):
-        lipschitz_ws[idx] = raw_hess @ X[:, j] ** 2
-
-    return lipschitz_ws


### PR DESCRIPTION
fixes #256 


Hard to test properly, but the following now works fine:
```python
import numpy as np
import matplotlib.pyplot as plt
from sklearn.model_selection import train_test_split
from numpy.linalg import norm
from skglm.utils.jit_compilation import compiled_clone

from skglm import GeneralizedLinearEstimator
from skglm import datafits
from skglm import penalties
from skglm.solvers import ProxNewton
from skglm.utils.data import make_correlated_data

X, y, _ = make_correlated_data(500, 5000, random_state=0)

y = np.abs(y) // 1

# datafit = compiled_clone(datafits.Quadratic())
datafit = compiled_clone(datafits.Poisson())
penalty = compiled_clone(penalties.L1(alpha=1))
alpha_max = penalty.alpha_max(datafit.gradient(X, y, np.zeros(len(y))))

penalty.alpha = alpha_max / 10

solver = ProxNewton(verbose=3, max_iter=20, warm_start=True, fit_intercept=False, tol=1e-4, ws_strategy="fixedpoint", max_pn_iter=20)

solver.solve(X, y, datafit, penalty)
```