### PR TITLE
Docstring update for L2 penalty in SparseLogisticRegression

### DIFF
--- a/doc/changes/0.4.rst
+++ b/doc/changes/0.4.rst
@@ -6,7 +6,7 @@ Version 0.4 (in progress)
 - Add support and tutorial for positive coefficients to :ref:`Group Lasso Penalty <skglm.penalties.WeightedGroupL2>` (PR: :gh:`221`)
 - Check compatibility with datafit and penalty in solver (PR :gh:`137`)
 - Add support to weight samples in the quadratic datafit :ref:`Weighted Quadratic Datafit <skglm.datafit.WeightedQuadratic>` (PR: :gh:`258`)
-
+- Add support for ElasticNet regularization (`penalty="l1_plus_l2"`) to :ref:`SparseLogisticRegression <skglm.SparseLogisticRegression>` (PR: :gh:`244`)
 
 Version 0.3.1 (2023/12/21)
 --------------------------

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -959,12 +959,12 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
 
     The optimization objective for sparse Logistic regression is:
 
-    .. math:: 
+    .. math::
         \frac{1}{n_{\text{samples}}} \sum_{i=1}^{n_{\text{samples}}}
         \log\left(1 + \exp(-y_i x_i^T w)\right)
         + \alpha \cdot \left( \text{l1_ratio} \cdot \|w\|_1 +
         (1 - \text{l1_ratio}) \cdot \|w\|_2^2 \right)
-    
+
     By default, ``l1_ratio=1.0`` corresponds to Lasso (pure L1 penalty).
     When ``0 < l1_ratio < 1``, the penalty is a convex combination of L1 and L2
     (i.e., ElasticNet). ``l1_ratio=0.0`` corresponds to Ridge (pure L2), but note
@@ -977,9 +977,9 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
 
     l1_ratio : float, default=1.0
         The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``.
-        Only used when ``penalty="l1_plus_l2"``. 
-        For ``l1_ratio = 0`` the penalty is an L2 penalty. 
-        ``For l1_ratio = 1`` it is an L1 penalty.  
+        Only used when ``penalty="l1_plus_l2"``.
+        For ``l1_ratio = 0`` the penalty is an L2 penalty.
+        ``For l1_ratio = 1`` it is an L1 penalty.
         For ``0 < l1_ratio < 1``, the penalty is a combination of L1 and L2.
 
     tol : float, optional

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -960,10 +960,9 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
     The optimization objective for sparse Logistic regression is:
 
     .. math::
-        \frac{1}{n_{\text{samples}}} \sum_{i=1}^{n_{\text{samples}}}
-        \log\left(1 + \exp(-y_i x_i^T w)\right)
-        + \alpha \cdot \left( \text{l1_ratio} \cdot \|w\|_1 +
-        (1 - \text{l1_ratio}) \cdot \|w\|_2^2 \right)
+        1 / n_"samples" \sum_{i=1}^{n_"samples"} log(1 + exp(-y_i xx x_i^T xx w))
+        + tt"l1_ratio" xx alpha ||w||_1
+        + (1 - tt"l1_ratio") xx alpha/2 ||w||_2 ^ 2
 
     By default, ``l1_ratio=1.0`` corresponds to Lasso (pure L1 penalty).
     When ``0 < l1_ratio < 1``, the penalty is a convex combination of L1 and L2

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -960,7 +960,7 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
     The optimization objective for sparse Logistic regression is:
 
     .. math::
-        1 / n_"samples" \sum_{i=1}^{n_"samples"} log(1 + exp(-y_i xx x_i^T xx w))
+        1 / n_"samples" \sum_{i=1}^{n_"samples"} log(1 + exp(-y_i x_i^T w))
         + tt"l1_ratio" xx alpha ||w||_1
         + (1 - tt"l1_ratio") xx alpha/2 ||w||_2 ^ 2
 

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -959,8 +959,16 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
 
     The optimization objective for sparse Logistic regression is:
 
-    .. math:: 1 / n_"samples" sum_(i=1)^(n_"samples") log(1 + exp(-y_i x_i^T w))
-        + alpha ||w||_1
+    .. math:: 
+        \frac{1}{n_{\text{samples}}} \sum_{i=1}^{n_{\text{samples}}}
+        \log\left(1 + \exp(-y_i x_i^T w)\right)
+        + \alpha \cdot \left( \text{l1_ratio} \cdot \|w\|_1 +
+        (1 - \text{l1_ratio}) \cdot \|w\|_2^2 \right)
+    
+    By default, ``l1_ratio=1.0`` corresponds to Lasso (pure L1 penalty).
+    When ``0 < l1_ratio < 1``, the penalty is a convex combination of L1 and L2
+    (i.e., ElasticNet). ``l1_ratio=0.0`` corresponds to Ridge (pure L2), but note
+    that pure Ridge is not typically used with this class.
 
     Parameters
     ----------
@@ -968,10 +976,11 @@ class SparseLogisticRegression(LinearClassifierMixin, SparseCoefMixin, BaseEstim
         Regularization strength; must be a positive float.
 
     l1_ratio : float, default=1.0
-        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``. For
-        ``l1_ratio = 0`` the penalty is an L2 penalty. ``For l1_ratio = 1`` it
-        is an L1 penalty.  For ``0 < l1_ratio < 1``, the penalty is a
-        combination of L1 and L2.
+        The ElasticNet mixing parameter, with ``0 <= l1_ratio <= 1``.
+        Only used when ``penalty="l1_plus_l2"``. 
+        For ``l1_ratio = 0`` the penalty is an L2 penalty. 
+        ``For l1_ratio = 1`` it is an L1 penalty.  
+        For ``0 < l1_ratio < 1``, the penalty is a combination of L1 and L2.
 
     tol : float, optional
         Stopping criterion for the optimization.


### PR DESCRIPTION
## Context of the PR

This PR finalizes and replaces [#244](https://github.com/scikit-learn-contrib/skglm/pull/244), which was stalled. The PR adds ElasticNet regularization support to skglm.SparseLogisticRegression via the penalty="l1_plus_l2" option and l1_ratio parameter. All technical steps have been solved in previous PRs. This is just a docstring update. 

## Contributions of the PR

Updated class-level docstring and l1_ratio parameter doc to SparseLogisticRegression

### Checks before merging PR

- [ yes ] added documentation for any new feature
- [no, already pushed in previous PR] added unit tests 
- [yes ] edited the [what's new](../doc/changes/0.4.rst) 
