### PR TITLE
MNT fix failing slope test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         conda install rpy2 -c conda-forge
         pip install statsmodels cvxopt
-        pip install git+https://github.com/jolars/sortedl1.git
+        pip install sortedl1
         # for testing Cox estimator
         pip install lifelines
         pip install pandas

--- a/skglm/tests/test_penalties.py
+++ b/skglm/tests/test_penalties.py
@@ -97,7 +97,12 @@ def test_slope():
     # q = 0.1
     # alphas = lambda_sequence(
     #     X, y, fit_intercept=False, reg=alpha / alpha_max, q=q)
-    clf = SlopeEst(alpha=0.01, fit_intercept=False).fit(X, y)
+    clf = SlopeEst(
+        alpha=0.01,
+        fit_intercept=False,
+        scaling = "none",
+        centering = "none"
+    ).fit(X, y)
     alphas = clf.lambda_
     ours = GeneralizedLinearEstimator(
         penalty=SLOPE(clf.alpha * alphas),

--- a/skglm/tests/test_penalties.py
+++ b/skglm/tests/test_penalties.py
@@ -98,10 +98,7 @@ def test_slope():
     # alphas = lambda_sequence(
     #     X, y, fit_intercept=False, reg=alpha / alpha_max, q=q)
     clf = SlopeEst(
-        alpha=0.01,
-        fit_intercept=False,
-        scaling = "none",
-        centering = "none"
+        alpha=0.01, fit_intercept=False, scaling="none", centering="none"
     ).fit(X, y)
     alphas = clf.lambda_
     ours = GeneralizedLinearEstimator(

--- a/skglm/tests/test_penalties.py
+++ b/skglm/tests/test_penalties.py
@@ -98,14 +98,14 @@ def test_slope():
     # alphas = lambda_sequence(
     #     X, y, fit_intercept=False, reg=alpha / alpha_max, q=q)
     clf = SlopeEst(
-        alpha=0.01, fit_intercept=False, scaling="none", centering="none"
+        alpha=0.01, fit_intercept=False, tol=1e-6
     ).fit(X, y)
     alphas = clf.lambda_
     ours = GeneralizedLinearEstimator(
         penalty=SLOPE(clf.alpha * alphas),
         solver=FISTA(max_iter=1000, tol=tol, opt_strategy="fixpoint"),
     ).fit(X, y)
-    np.testing.assert_allclose(ours.coef_, clf.coef_, rtol=1e-5)
+    np.testing.assert_allclose(ours.coef_, np.squeeze(clf.coef_), rtol=1e-3)
 
 
 @pytest.mark.parametrize("fit_intercept", [True, False])


### PR DESCRIPTION
## Context of the PR

<!--

Is the PR meant to fix a bug? implement a new feature...
Any detail to be able to relate the PR changes

-->

I think the failing test for SLOPE observed in #282 was due to the Slope estimator
normalizing data by default. 
## Contributions of the PR

<!-- List the contribution of the PR -->

I've turned off normalization in the test now.
(I realize that it might not be completely kosher to normalize in these sklearn
estimators so I'll change the default for the sortedl1 package as well, but
we might as well make it explicit here).

The test is working at least locally for me now.

### Checks before merging PR

- [ ] added documentation for any new feature
- [ ] added unit tests
- [ ] edited the [what's new](../doc/changes/whats_new.rst) (if applicable)