### PR TITLE
issue #297:  visualize group sparsity in example group_logistic_regression

### DIFF
--- a/examples/plot_group_logistic_regression.py
+++ b/examples/plot_group_logistic_regression.py
@@ -61,6 +61,6 @@ plt.show()
 
 # %%
 # This plot shows the L2 norm of the coefficients for each group.
-# Groups with a norm close to zero have been set inactive by the model,
+# Groups with a zero norm have been set inactive by the model,
 # illustrating how Group Logistic Regression enforces sparsity at the group level.
 # (Note: This example uses a tiny synthetic dataset, so the pattern has limited interpretability.)

--- a/examples/plot_group_logistic_regression.py
+++ b/examples/plot_group_logistic_regression.py
@@ -16,6 +16,8 @@ from skglm.penalties import WeightedGroupL2
 from skglm.solvers import GroupProxNewton
 from skglm.utils.data import make_correlated_data, grp_converter
 
+import matplotlib.pyplot as plt
+
 n_features = 30
 X, y, _ = make_correlated_data(
     n_samples=10, n_features=30, random_state=0)
@@ -42,3 +44,23 @@ clf.fit(X, y)
 # %%
 # Fit check that groups are either all 0 or all non zero
 print(clf.coef_.reshape(-1, grp_size))
+
+# %%
+# Visualise group-level sparsity
+
+coef_by_group = clf.coef_.reshape(-1, grp_size)
+group_norms = np.linalg.norm(coef_by_group, axis=1)
+
+plt.figure(figsize=(8, 4))
+plt.bar(np.arange(n_groups), group_norms)
+plt.xlabel("Group index")
+plt.ylabel("L2 norm of coefficients")
+plt.title("Group Sparsity Pattern")
+plt.tight_layout()
+plt.show()
+
+# %%
+# This plot shows the L2 norm of the coefficients for each group.
+# Groups with a norm close to zero have been set inactive by the model,
+# illustrating how Group Logistic Regression enforces sparsity at the group level.
+# (Note: This example uses a tiny synthetic dataset, so the pattern has limited interpretability.)


### PR DESCRIPTION
## Context

The example `plot_group_logistic_regression.py` was missing a plot, so it looked empty in the doc gallery.

## Contributions of the PR

This PR adds a simple bar plot to the example `plot_group_logistic_regression.py` to visualize group sparsity after training.
The plot shows the L2 norm of coefficients for each group, illustrating which groups were kept or removed by the regularization.

Note:
Due to the small synthetic dataset, interpretability of the resulting sparsity pattern is limited.

## Checklist before merging
- [x] The code runs correctly locally.
- [x] The visualization is correctly generated.
- [x] Documentation gallery should now show a figure for this example.
- [ ] Consider discussing an alternative plot (e.g. heatmap)

---

Closes issue #297