### PR TITLE
Issue#296 -Precompile skglm to cache JIT

### DIFF
--- a/examples/plot_compare_time.py
+++ b/examples/plot_compare_time.py
@@ -65,6 +65,12 @@ for ax, model, l1_ratio in zip(axarr, models, [1, 0.5]):
     dict_ours[model].max_iter = 10_000
     w_star = dict_ours[model].fit(X, y).coef_
     pobj_star = compute_obj(X, y, w_star, alpha, l1_ratio)
+
+    # Pre-compile skglm so no JIT shows up in timing
+    for n_iter_us in range(1, 10):
+        dict_ours[model].max_iter = n_iter_us
+        _ = dict_ours[model].fit(X, y).coef_
+
     for n_iter_sklearn in np.unique(np.geomspace(1, 50, num=15).astype(int)):
         dict_sklearn[model].max_iter = n_iter_sklearn
 


### PR DESCRIPTION
## Context of the PR

Cash compilation times in timing comparison

## Contributions of the PR

Pre-warm skglm (dummy .fit) so its compile time is excluded:

 
skglm uses JIT (Numba/Cython), so the first .fit(...) pays a multi-second compile cost; pre-running a dummy .fit(max_iter=10_000) (and even one at each small max_iter) moves all that out of the timed loop. (=cache compile step)
scikit-learn is already AOT-compiled, so there’s no hidden JIT to hide—its very first .fit is a fair measurement of solver speed.


### Checks before merging PR

- [ ] review if understanding of cache compilation time is correct 
