### PR TITLE
MNT - fix regression introduced in #270

### DIFF
--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -102,11 +102,6 @@ def _glm_fit(X, y, model, datafit, penalty, solver):
 
     n_samples, n_features = X_.shape
 
-    # if issparse(X):
-    #     datafit.initialize_sparse(X_.data, X_.indptr, X_.indices, y)
-    # else:
-    #     datafit.initialize(X_, y)
-
     # if model.warm_start and hasattr(model, 'coef_') and model.coef_ is not None:
     if solver.warm_start and hasattr(model, 'coef_') and model.coef_ is not None:
         if isinstance(datafit, QuadraticSVC):

--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -102,10 +102,10 @@ def _glm_fit(X, y, model, datafit, penalty, solver):
 
     n_samples, n_features = X_.shape
 
-    if issparse(X):
-        datafit.initialize_sparse(X_.data, X_.indptr, X_.indices, y)
-    else:
-        datafit.initialize(X_, y)
+    # if issparse(X):
+    #     datafit.initialize_sparse(X_.data, X_.indptr, X_.indices, y)
+    # else:
+    #     datafit.initialize(X_, y)
 
     # if model.warm_start and hasattr(model, 'coef_') and model.coef_ is not None:
     if solver.warm_start and hasattr(model, 'coef_') and model.coef_ is not None:


### PR DESCRIPTION
## Context of the PR

fixes #302,
The regression is caused (after #270) by executing an extra initialization of the datafit with uncompiled datafit

## Contributions of the PR

- remove unnecessary initialization of the datafit

## Check it fixed

```python
import time
from skglm import Lasso
from libsvmdata import fetch_libsvm

X, y = fetch_libsvm("news20.binary")
alpha = abs(X.T @ y).max() / len(y) / 2
model = Lasso(alpha=alpha, fit_intercept=False, tol=1e-12)

# cache compilation
t0 = time.time()
model.fit(X, y)
print("Initial fit:", time.time() - t0)

for _ in range(2):
    t0 = time.time()
    model.fit(X, y)
    print("Time to fit:", time.time() - t0)

# output
# Initial fit: 2.6478769779205322
# Time to fit: 0.20598602294921875
# Time to fit: 0.22588682174682617
```

### Checks before merging PR

- ~[ ] added documentation for any new feature~
- ~[ ] added unit tests~
- ~[ ] edited the [what's new](../doc/changes/whats_new.rst) (if applicable)~
