### PR TITLE
first try at simple quantile huber

### DIFF
--- a/examples/plot_smooth_quantile.py
+++ b/examples/plot_smooth_quantile.py
@@ -1,0 +1,75 @@
+"""
+===========================================
+Smooth Quantile Regression Example
+===========================================
+
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import time
+from sklearn.datasets import make_regression
+from sklearn.preprocessing import StandardScaler
+from sklearn.linear_model import QuantileRegressor
+from skglm.experimental.smooth_quantile_regressor import SmoothQuantileRegressor
+from skglm.experimental.quantile_huber import QuantileHuber
+
+X, y = make_regression(n_samples=1000, n_features=10, noise=0.1, random_state=42)
+X = StandardScaler().fit_transform(X)
+tau = 0.75
+
+t0 = time.time()
+reg_skglm = SmoothQuantileRegressor(quantile=tau).fit(X, y)
+t1 = time.time()
+reg_sklearn = QuantileRegressor(quantile=tau, alpha=0.1, solver='highs').fit(X, y)
+t2 = time.time()
+
+y_pred_skglm, y_pred_sklearn = reg_skglm.predict(X), reg_sklearn.predict(X)
+coverage_skglm = np.mean(y <= y_pred_skglm)
+coverage_sklearn = np.mean(y <= y_pred_sklearn)
+
+print(f"\nTiming: skglm={t1-t0:.3f}s, sklearn={t2-t1:.3f}s, "
+      f"speedup={(t2-t1)/(t1-t0):.1f}x")
+print(f"Coverage (target {tau}): skglm={coverage_skglm:.3f}, "
+      f"sklearn={coverage_sklearn:.3f}")
+print(f"Non-zero coefs: skglm={np.sum(reg_skglm.coef_ != 0)}, "
+      f"sklearn={np.sum(reg_sklearn.coef_ != 0)}")
+
+
+# Visualizations
+def pinball(y_true, y_pred):
+    diff = y_true - y_pred
+    return np.mean(np.where(diff >= 0, tau * diff, (1 - tau) * -diff))
+
+
+print(f"Pinball loss: skglm={pinball(y, y_pred_skglm):.4f}, "
+      f"sklearn={pinball(y, y_pred_sklearn):.4f}")
+
+plt.figure(figsize=(12, 5))
+plt.subplot(121)
+residuals = np.linspace(-2, 2, 1000)
+for delta in [1.0, 0.5, 0.1]:
+    loss = QuantileHuber(quantile=tau, delta=delta)
+    losses = [loss.value(np.array([r]), np.array([[1]]), np.array([0]))
+              for r in residuals]
+    plt.plot(residuals, losses, label=f'δ={delta}')
+plt.plot(residuals, [tau * max(r, 0) + (1 - tau) * max(-r, 0)
+                     for r in residuals], 'k--', label='Pinball')
+plt.axvline(x=0, color='k', linestyle='--', alpha=0.3)
+plt.xlabel('Residual (y - y_pred)')
+plt.ylabel('Loss')
+plt.title('Quantile Huber Loss (τ=0.75)')
+plt.legend()
+plt.grid(True, alpha=0.3)
+
+plt.subplot(122)
+plt.hist(y - y_pred_skglm, bins=50, alpha=0.5, label='skglm')
+plt.hist(y - y_pred_sklearn, bins=50, alpha=0.5, label='sklearn')
+plt.axvline(0, color='k', linestyle='--')
+plt.xlabel('Residual (y - y_pred)')
+plt.ylabel('Count')
+plt.title('Residuals Histogram')
+plt.legend()
+plt.grid(True, alpha=0.3)
+plt.tight_layout()
+plt.show()

--- a/skglm/experimental/__init__.py
+++ b/skglm/experimental/__init__.py
@@ -2,6 +2,8 @@ from .reweighted import IterativeReweightedL1
 from .sqrt_lasso import SqrtLasso, SqrtQuadratic
 from .pdcd_ws import PDCD_WS
 from .quantile_regression import Pinball
+from .quantile_huber import QuantileHuber
+from .smooth_quantile_regressor import SmoothQuantileRegressor
 
 __all__ = [
     IterativeReweightedL1,
@@ -9,4 +11,6 @@ __all__ = [
     Pinball,
     SqrtQuadratic,
     SqrtLasso,
+    QuantileHuber,
+    SmoothQuantileRegressor,
 ]

--- a/skglm/experimental/quantile_huber.py
+++ b/skglm/experimental/quantile_huber.py
@@ -1,0 +1,124 @@
+import numpy as np
+from numba import float64
+from skglm.datafits.single_task import Huber
+from skglm.utils.sparse_ops import spectral_norm
+
+
+class QuantileHuber(Huber):
+    r"""Quantile Huber loss for quantile regression.
+
+    Implements the smoothed pinball loss with quadratic region:
+
+    .. math::
+
+       \rho_\tau^\delta(r) =
+       \begin{cases}
+           \tau\, r - \dfrac{\delta}{2}, & \text{if } r \ge \delta,\\
+           \dfrac{\tau r^{2}}{2\delta}, & \text{if } 0 \le r < \delta,\\
+           \dfrac{(1-\tau) r^{2}}{2\delta}, & \text{if } -\delta < r < 0,\\
+           (\tau - 1)\, r - \dfrac{\delta}{2}, & \text{if } r \le -\delta.
+       \end{cases}
+
+    Parameters
+    ----------
+    quantile : float, default=0.5
+        Desired quantile level between 0 and 1.
+    delta : float, default=1.0
+        Width of quadratic region.
+
+    References
+    ----------
+    Chen, C. (2007). A Finite Smoothing Algorithm for Quantile Regression.
+    Journal of Computational and Graphical Statistics, 16(1), 136–164.
+    http://www.jstor.org/stable/27594233
+    """
+
+    def __init__(self, quantile=0.5, delta=1.0):
+        if not 0 < quantile < 1:
+            raise ValueError("quantile must be between 0 and 1")
+        self.delta = float(delta)
+        self.quantile = float(quantile)
+
+    def get_spec(self):
+        return (('delta', float64), ('quantile', float64))
+
+    def params_to_dict(self):
+        return dict(delta=self.delta, quantile=self.quantile)
+
+    def _loss_and_grad_scalar(self, residual):
+        """Calculate loss and gradient for a single residual."""
+        tau = self.quantile
+        delta = self.delta
+        abs_r = abs(residual)
+
+        # Quadratic core: |r| ≤ delta
+        if abs_r <= delta:
+            if residual >= 0:
+                # 0 ≤ r ≤ delta
+                loss = tau * residual**2 / (2 * delta)
+                grad = tau * residual / delta
+            else:
+                # -delta ≤ r < 0
+                loss = (1 - tau) * residual**2 / (2 * delta)
+                grad = (1 - tau) * residual / delta
+            return loss, grad
+
+        # Linear tails: |r| > delta
+        if residual > delta:
+            loss = tau * (residual - delta / 2)
+            grad = tau
+            return loss, grad
+        else:
+            loss = (1 - tau) * (-residual - delta / 2)
+            grad = tau - 1
+            return loss, grad
+
+    def value(self, y, w, Xw):
+        """Compute the quantile Huber loss value."""
+        residuals = y - Xw
+        loss = np.zeros_like(residuals)
+        for i, r in enumerate(residuals):
+            loss[i], _ = self._loss_and_grad_scalar(r)
+        return np.mean(loss)
+
+    def raw_grad(self, y, Xw):
+        """Compute gradient of datafit w.r.t Xw."""
+        residuals = y - Xw
+        grad = np.zeros_like(residuals)
+        for i, r in enumerate(residuals):
+            _, grad[i] = self._loss_and_grad_scalar(r)
+        return -grad
+
+    def get_lipschitz(self, X, y):
+        """Compute coordinate-wise Lipschitz constants."""
+        weight = max(self.quantile, 1 - self.quantile)
+        return weight * (X ** 2).sum(axis=0) / (len(y) * self.delta)
+
+    def get_global_lipschitz(self, X, y):
+        """Compute global Lipschitz constant."""
+        weight = max(self.quantile, 1 - self.quantile)
+        return weight * np.linalg.norm(X, 2) ** 2 / (len(y) * self.delta)
+
+    def get_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
+        """Compute coordinate-wise Lipschitz constants for sparse X."""
+        n_samples = len(y)
+        weight = max(self.quantile, 1 - self.quantile)
+        n_features = len(X_indptr) - 1
+        lipschitz = np.zeros(n_features, dtype=X_data.dtype)
+        for j in range(n_features):
+            nrm2 = 0.0
+            for idx in range(X_indptr[j], X_indptr[j + 1]):
+                nrm2 += X_data[idx] ** 2
+            lipschitz[j] = weight * nrm2 / (n_samples * self.delta)
+        return lipschitz
+
+    def get_global_lipschitz_sparse(self, X_data, X_indptr, X_indices, y):
+        """Compute global Lipschitz constant for sparse X."""
+        n_samples = len(y)
+        weight = max(self.quantile, 1 - self.quantile)
+        return weight * spectral_norm(
+            X_data, X_indptr, X_indices, n_samples
+        ) ** 2 / (n_samples * self.delta)
+
+    def intercept_update_step(self, y, Xw):
+        return -np.mean(self.raw_grad(y, Xw))

--- a/skglm/experimental/smooth_quantile_regressor.py
+++ b/skglm/experimental/smooth_quantile_regressor.py
@@ -1,0 +1,75 @@
+import numpy as np
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.utils.validation import check_X_y, check_array
+from ..solvers import FISTA
+from ..penalties import L1
+from ..estimators import GeneralizedLinearEstimator
+from .quantile_huber import QuantileHuber
+
+
+class SmoothQuantileRegressor(BaseEstimator, RegressorMixin):
+    """Quantile regression with progressive smoothing using Huberized loss."""
+
+    def __init__(self, quantile=0.75, alpha=1e-8, max_iter=1000, tol=1e-6,
+                 delta_init=1.0, delta_final=1e-4, n_deltas=10, fit_intercept=True):
+        self.quantile = quantile
+        self.alpha = alpha
+        self.max_iter = max_iter
+        self.tol = tol
+        self.delta_init = delta_init
+        self.delta_final = delta_final
+        self.n_deltas = n_deltas
+        self.fit_intercept = fit_intercept
+        self.intercept_ = 0.0
+
+    def fit(self, X, y):
+        """Fit using FISTA with decreasing smoothing parameter delta.
+
+        For each delta level:
+        - Update coefficients using FISTA
+        - Update intercept using gradient step
+        """
+        X, y = check_X_y(X, y)
+        w = np.zeros(X.shape[1])
+        intercept = np.quantile(y, self.quantile) if self.fit_intercept else 0.0
+
+        for delta in np.geomspace(self.delta_init, self.delta_final, self.n_deltas):
+            datafit = QuantileHuber(quantile=self.quantile, delta=delta)
+            est = GeneralizedLinearEstimator(
+                datafit=datafit,
+                penalty=L1(alpha=self.alpha),
+                solver=FISTA(max_iter=self.max_iter, tol=self.tol)
+            )
+            est.coef_ = w
+            est.fit(X, y)
+            w = est.coef_
+
+            if self.fit_intercept:
+                pred = X @ w + intercept
+                lipschitz = datafit.get_global_lipschitz(X, y)
+                grad = np.mean(datafit.raw_grad(y, pred))
+                intercept -= grad / lipschitz
+
+            # Debug prints
+            residuals = y - X.dot(w) - intercept
+            obj_value = datafit.value(residuals, None, residuals) + \
+                self.alpha * np.sum(np.abs(w))
+            print(f"Delta: {delta:.6f}, Objective: {obj_value:.4f}, "
+                  f"Intercept: {intercept:.4f}, "
+                  f"Non-zero coefs: {np.sum(np.abs(w) > 1e-6)}, "
+                  f"Lipschitz: {lipschitz:.4f}")
+            print(f"Residual stats - mean: {np.mean(residuals):.4f}, "
+                  f"std: {np.std(residuals):.4f}, "
+                  f"min: {np.min(residuals):.4f}, "
+                  f"max: {np.max(residuals):.4f}")
+
+            coverage = np.mean(y <= X.dot(w) + intercept)
+            print(f"Coverage: {coverage:.4f} (target: {self.quantile:.4f})")
+
+        self.coef_, self.intercept_ = w, intercept
+        return self
+
+    def predict(self, X):
+        """Predict using the fitted model."""
+        check_array(X)
+        return X @ self.coef_ + self.intercept_


### PR DESCRIPTION
## Context of the PR

This PR implements a smooth quantile regression estimator using a Huberized loss with progressive smoothing. The goal is to provide a faster alternative to scikit-learn's QuantileRegressor while maintaining similar accuracy.
(closes #276 )
(Also it aims to simplify earlier approaches done in PR #306 )

## Contributions of the PR

Added QuantileHuber loss in skglm/experimental/quantile_huber.py

Added SmoothQuantileRegressor class in skglm/experimental/smooth_quantile_regressor.py:
- Uses FISTA solver with L1 regularization
- Implements progressive smoothing from delta_init to delta_final
- Includes intercept updates using gradient steps

Added example in examples/plot_smooth_quantile.py


### Checks before merging PR

- [ ] added documentation for any new feature
- [ ] added unit tests
- [ ] edited the [what's new](../doc/changes/whats_new.rst) (if applicable)
