### PR TITLE
FIX - add `alpha` to SLOPE penalty

### DIFF
--- a/skglm/penalties/non_separable.py
+++ b/skglm/penalties/non_separable.py
@@ -14,6 +14,8 @@ class SLOPE(BasePenalty):
         Contain regularization levels for every feature.
         When ``alphas`` contain a single unique value, ``SLOPE``
         is equivalent to the ``L1``penalty.
+    alpha : float, default=1.0
+        Scaling factor for the penalty. `alphas` is multiplied by this value.
 
     References
     ----------
@@ -23,24 +25,26 @@ class SLOPE(BasePenalty):
         https://doi.org/10.1214/15-AOAS842
     """
 
-    def __init__(self, alphas):
+    def __init__(self, alphas, alpha=1):
         self.alphas = alphas
+        self.alpha = alpha
 
     def get_spec(self):
         spec = (
+            ('alpha', float64),
             ('alphas', float64[:]),
         )
         return spec
 
     def params_to_dict(self):
-        return dict(alphas=self.alphas)
+        return dict(alphas=self.alphas, alpha=self.alpha)
 
     def value(self, w):
         """Compute the value of SLOPE at w."""
-        return np.sum(np.sort(np.abs(w)) * self.alphas[::-1])
+        return np.sum(np.sort(np.abs(w)) * self.alphas[::-1] * self.alpha)
 
     def prox_vec(self, x, stepsize):
-        alphas = self.alphas
+        alphas = self.alphas * self.alpha
         prox = np.zeros_like(x)
 
         abs_x = np.abs(x)

--- a/skglm/tests/test_estimators.py
+++ b/skglm/tests/test_estimators.py
@@ -621,9 +621,10 @@ def test_SparseLogReg_elasticnet(X, l1_ratio):
     np.testing.assert_allclose(
         estimator_sk.intercept_, estimator_ours.intercept_, rtol=1e-4)
 
+
 def test_SLOPE_printing():
     alphas = [0.5, 0.1]
-    model = GeneralizedLinearEstimator(penalty = SLOPE(alphas))
+    model = GeneralizedLinearEstimator(penalty=SLOPE(alphas))
     res = repr(model)
     assert isinstance(res, str)
 

--- a/skglm/tests/test_estimators.py
+++ b/skglm/tests/test_estimators.py
@@ -621,6 +621,12 @@ def test_SparseLogReg_elasticnet(X, l1_ratio):
     np.testing.assert_allclose(
         estimator_sk.intercept_, estimator_ours.intercept_, rtol=1e-4)
 
+def test_SLOPE_printing():
+    alphas = [0.5, 0.1]
+    model = GeneralizedLinearEstimator(penalty = SLOPE(alphas))
+    res = repr(model)
+    assert isinstance(res, str)
+
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
## Context of the PR

<!--

Is the PR meant to fix a bug? implement a new feature...
Any detail to be able to relate the PR changes

-->

See #315 

## Contributions of the PR

<!-- List the contribution of the PR -->

Add `alpha` to make `repr()` work on objects created with the SLOPE penalty. Closes #315.

### Checks before merging PR

- [x] added documentation for any new feature
- [x] added unit tests
- [x] ~edited the [what's new](../doc/changes/whats_new.rst) (if applicable)~
