### PR TITLE
FIX match sklearn behavior for Poisson and PoissonGroup datafits

### DIFF
--- a/skglm/estimators.py
+++ b/skglm/estimators.py
@@ -18,8 +18,9 @@ from sklearn.utils._param_validation import Interval, StrOptions
 from sklearn.multiclass import OneVsRestClassifier, check_classification_targets
 
 from skglm.solvers import AndersonCD, MultiTaskBCD, GroupBCD, ProxNewton, LBFGS
-from skglm.datafits import (Cox, Quadratic, Logistic, QuadraticSVC,
-                            QuadraticMultiTask, QuadraticGroup,)
+from skglm.datafits import (
+    Cox, Quadratic, Logistic, Poisson, PoissonGroup, QuadraticSVC,
+    QuadraticMultiTask, QuadraticGroup,)
 from skglm.penalties import (L1, WeightedL1, L1_plus_L2, L2, WeightedGroupL2,
                              MCPenalty, WeightedMCPenalty, IndicatorBox, L2_1)
 from skglm.utils.data import grp_converter
@@ -265,6 +266,8 @@ class GeneralizedLinearEstimator(LinearModel):
             else:
                 indices = scores.argmax(axis=1)
             return self.classes_[indices]
+        elif isinstance(self.datafit, (Poisson, PoissonGroup)):
+            return np.exp(self._decision_function(X))
         else:
             return self._decision_function(X)
 


### PR DESCRIPTION
closes #320 

It's definitely hacky and a better way would be to have datafits implement their own `inverse_link` attribute, then if hasattr self datafit, inverse_link, we apply it in GLE.fit()

But for now it's a good enough quick fix and i don't want to take a decision on the design. We can come back to it later.

@floriankozikowski could you send a follow-up PR with a unit test checking that on simple data we get the same prediction as sklearn ? And do it for Gamma regressor too