### PR TITLE
FIX WeightedL1GroupL2 penalty proximal operator computation

### DIFF
--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -455,7 +455,9 @@ class WeightedL1GroupL2(BasePenalty):
 
     def prox_1group(self, value, stepsize, g):
         """Compute the proximal operator of group ``g``."""
-        res = ST_vec(value, self.alpha * stepsize * self.weights_features[g])
+        grp_ptr, grp_indices = self.grp_ptr, self.grp_indices
+        grp_g_indices = grp_indices[grp_ptr[g]: grp_ptr[g+1]]
+        res = ST_vec(value, self.alpha * stepsize * self.weights_features[grp_g_indices])
         return BST(res, self.alpha * stepsize * self.weights_groups[g])
 
     def is_penalized(self, n_groups):


### PR DESCRIPTION
Fixes #332 

No unit test to add yet, but the following example now produces result more in line with expectations. (above: before; below: after)

```python
import numpy as np
import matplotlib.pyplot as plt

from skglm.solvers import GroupBCD
from skglm.datafits import QuadraticGroup
from skglm import GeneralizedLinearEstimator
from skglm.penalties import WeightedL1GroupL2
from skglm.utils.data import make_correlated_data, grp_converter

n_features = 30
X, y, _ = make_correlated_data(
    n_samples=10, n_features=30, random_state=0)

grp_size = 10  
n_groups = n_features // grp_size
grp_indices, grp_ptr = grp_converter(grp_size, n_features)
n_groups = len(grp_ptr) - 1
weights_g = np.ones(n_groups, dtype=np.float64)
weights_f = 0.5 * np.ones(n_features)
weights_f[1] = 0 # <- added: no penalty on feature 1
penalty = WeightedL1GroupL2(
    alpha=0.5, weights_groups=weights_g,
    weights_features=weights_f, grp_indices=grp_indices, grp_ptr=grp_ptr)

datafit = QuadraticGroup(grp_ptr, grp_indices)
solver = GroupBCD(ws_strategy="fixpoint", verbose=1, fit_intercept=False, tol=1e-10)

model = GeneralizedLinearEstimator(datafit, penalty, solver=solver)

clf = GeneralizedLinearEstimator(datafit, penalty, solver)
clf.fit(X, y)

plt.imshow(clf.coef_.reshape(-1, grp_size) != 0, cmap='Greys')
plt.title("Non zero values (in black) in model coefficients")
plt.ylabel('Group index')
plt.xlabel('Feature index inside group')
plt.xticks(np.arange(grp_size))
plt.yticks(np.arange(n_groups));
```

<img width="554" height="234" alt="before" src="https://github.com/user-attachments/assets/a63ea978-1904-49b0-a9e7-af99e2d63d2b" />
<img width="554" height="234" alt="after" src="https://github.com/user-attachments/assets/9bb6bf11-5f15-4e24-88d0-4dd08eef9677" />
