### PR TITLE
FEAT use Newton for intercept update step in CD algorithm

### DIFF
--- a/doc/changes/0.6.rst
+++ b/doc/changes/0.6.rst
@@ -4,3 +4,4 @@ Version 0.6 (in progress)
 -------------------------
 
 - :class:`skglm.solvers.LBFGS` now supports fitting an intercept with the `fit_intercept` parameter.
+- The intercept update for the :class:`~skglm.datafits.Logistic` datafit is now a 1-D Newton step on the intercept subproblem (previously a gradient step at the global Lipschitz constant ``L_0 = 1/4``). This eliminates the slow convergence regime under response imbalance for direct-CD solvers (:class:`~skglm.solvers.AndersonCD`, :class:`~skglm.solvers.GroupBCD`) and inherits to :class:`~skglm.datafits.LogisticGroup`  (PR: :gh:`337`) 

--- a/skglm/datafits/single_task.py
+++ b/skglm/datafits/single_task.py
@@ -370,7 +370,9 @@ class Logistic(BaseDatafit):
         return grad / len(Xw)
 
     def intercept_update_step(self, y, Xw):
-        return np.mean(- y * sigmoid(- y * Xw)) / 4
+        # Newton step on the 1D intercept subproblem:
+        #     beta_0 <- beta_0 - (sum f'(Xw_i; y_i)) / (sum f''(Xw_i; y_i)).
+        return np.sum(self.raw_grad(y, Xw)) / np.sum(self.raw_hessian(y, Xw))
 
 
 class QuadraticSVC(BaseDatafit):

--- a/skglm/penalties/block_separable.py
+++ b/skglm/penalties/block_separable.py
@@ -457,7 +457,9 @@ class WeightedL1GroupL2(BasePenalty):
         """Compute the proximal operator of group ``g``."""
         grp_ptr, grp_indices = self.grp_ptr, self.grp_indices
         grp_g_indices = grp_indices[grp_ptr[g]: grp_ptr[g+1]]
-        res = ST_vec(value, self.alpha * stepsize * self.weights_features[grp_g_indices])
+        res = ST_vec(
+            value, self.alpha * stepsize * self.weights_features[grp_g_indices]
+        )
         return BST(res, self.alpha * stepsize * self.weights_groups[g])
 
     def is_penalized(self, n_groups):

--- a/skglm/tests/test_datafits.py
+++ b/skglm/tests/test_datafits.py
@@ -59,6 +59,50 @@ def test_log_datafit():
     np.testing.assert_almost_equal(-grad * (y + n_samples * grad), hess)
 
 
+def test_logistic_intercept_newton_step():
+    # The intercept update is a 1D Newton step on
+    #     beta_0 -> F(beta_0, beta) = mean log(1 + exp(-y(X beta + beta_0))).
+    # Check (a) the closed-form matches sum(raw_grad)/sum(raw_hessian), and
+    # (b) iterating the update converges quadratically to the analytic
+    # optimizer log(p/(1-p)) when beta = 0.
+    rng = np.random.RandomState(0)
+    n_samples = 200
+    y = np.where(rng.random(n_samples) < 0.95, 1.0, -1.0)  # mu_0 ~= 0.95
+    p_hat = (y == 1).mean()
+
+    df = Logistic()
+    Xw = np.zeros(n_samples)  # beta = 0, beta_0 = 0
+
+    step = df.intercept_update_step(y, Xw)
+    expected = np.sum(df.raw_grad(y, Xw)) / np.sum(df.raw_hessian(y, Xw))
+    np.testing.assert_allclose(step, expected)
+
+    intercept = 0.0
+    for _ in range(10):
+        intercept -= df.intercept_update_step(y, Xw + intercept)
+    np.testing.assert_allclose(intercept, np.log(p_hat / (1 - p_hat)), rtol=1e-8)
+
+
+def test_logistic_intercept_imbalanced_converges():
+    # Regression test for the Newton intercept update: on a strongly imbalanced
+    # logistic problem the previous gradient-strategy update (step 1/(4n)
+    # scaled gradient) stalled and failed to reach the tolerance within the
+    # default iteration budget. The Newton step converges quickly.
+    from skglm import SparseLogisticRegression
+
+    rng = np.random.RandomState(0)
+    n_samples, n_features = 300, 100
+    X = rng.randn(n_samples, n_features)
+    # mu_0 ~ 0.97
+    y = np.where(rng.random(n_samples) < 0.97, 1.0, -1.0)
+
+    tol = 1e-8
+    est = SparseLogisticRegression(
+        alpha=0.05, tol=tol, fit_intercept=True, max_iter=50,
+    ).fit(X, y)
+    assert est.stop_crit_ < tol
+
+
 def test_poisson():
     try:
         from statsmodels.discrete.discrete_model import Poisson as PoissonRegressor  # noqa


### PR DESCRIPTION
## Context of the PR

<!--

Is the PR meant to fix a bug? implement a new feature...
Any detail to be able to relate the PR changes

-->

The gradient-based update that's used in the coordinate descent strategy handles imbalanced reponses poorly and will stall convergence for the entire algorithm, requiring many more iterations or even fail to converge at all. The fix is easy, you just have to switch it to a Newton-base update instead. To make it even more robust, you could also use dampening, but the standard Newton step seems to work well except for some very pathological cases.

I am writing a paper on intercept updating for coordinate descent, which was motivated by the fact that many packages take different approaches to updating the intercept. And the strongest result is that basing the step on the global Lipschitz constant is by far the worst choice.

Here are some before-and-after plots of convergence. As you can see, even quite modest imbalance leads to poor convergence.

<img width="930" height="570" alt="skglm_pr_demo_gradient_37455d8e" src="https://github.com/user-attachments/assets/9a1da1b1-7c27-46b5-8b90-55d7954adb30" />

<img width="930" height="570" alt="skglm_pr_demo_newton_37455d8e" src="https://github.com/user-attachments/assets/ee211856-db64-4f44-b37e-431c0702ebec" />

## Contributions of the PR

<!-- List the contribution of the PR -->

- I modified the intercept update for the logistic datafit for the AndersonCD solver
- I added a news entry for 0.6
- I added a couple of unit tests

### Checks before merging PR

- [ ] added documentation for any new feature
- [x] added unit tests
- [ ] edited the [what's new](../doc/changes/whats_new.rst) (if applicable)
