### PR TITLE
Add WeightedL1_plus_L2 penalty

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -61,6 +61,7 @@ Penalties
    MCPenalty
    PositiveConstraint
    WeightedL1
+   WeightedL1_plus_L2
    WeightedGroupL2
    WeightedMCPenalty
    SCAD

--- a/doc/changes/0.6.rst
+++ b/doc/changes/0.6.rst
@@ -3,5 +3,7 @@
 Version 0.6 (in progress)
 -------------------------
 
+- Added support for wieghted ElasticNet penalty via :class:`skglm.penalties.WeightedL1_plus_L2`.
+
 - :class:`skglm.solvers.LBFGS` now supports fitting an intercept with the `fit_intercept` parameter.
-- The intercept update for the :class:`~skglm.datafits.Logistic` datafit is now a 1-D Newton step on the intercept subproblem (previously a gradient step at the global Lipschitz constant ``L_0 = 1/4``). This eliminates the slow convergence regime under response imbalance for direct-CD solvers (:class:`~skglm.solvers.AndersonCD`, :class:`~skglm.solvers.GroupBCD`) and inherits to :class:`~skglm.datafits.LogisticGroup`  (PR: :gh:`337`) 
+- The intercept update for the :class:`~skglm.datafits.Logistic` datafit is now a 1-D Newton step on the intercept subproblem (previously a gradient step at the global Lipschitz constant ``L_0 = 1/4``). This eliminates the slow convergence regime under response imbalance for direct-CD solvers (:class:`~skglm.solvers.AndersonCD`, :class:`~skglm.solvers.GroupBCD`) and inherits to :class:`~skglm.datafits.LogisticGroup`  (PR: :gh:`337`)

--- a/skglm/penalties/__init__.py
+++ b/skglm/penalties/__init__.py
@@ -1,7 +1,8 @@
 from .base import BasePenalty
 from .separable import (
     L1_plus_L2, L0_5, L1, L2, L2_3, MCPenalty, WeightedMCPenalty, SCAD,
-    WeightedL1, IndicatorBox, PositiveConstraint, LogSumPenalty
+    WeightedL1, WeightedL1_plus_L2, IndicatorBox, PositiveConstraint,
+    LogSumPenalty
 )
 from .block_separable import (
     L2_05, L2_1, BlockMCPenalty, BlockSCAD, WeightedGroupL2, WeightedL1GroupL2
@@ -13,6 +14,7 @@ from .non_separable import SLOPE
 __all__ = [
     BasePenalty,
     L1_plus_L2, L0_5, L1, L2, L2_3, MCPenalty, WeightedMCPenalty, SCAD, WeightedL1,
+    WeightedL1_plus_L2,
     IndicatorBox, PositiveConstraint, L2_05, L2_1, BlockMCPenalty, BlockSCAD,
     WeightedGroupL2, WeightedL1GroupL2, SLOPE, LogSumPenalty
 ]

--- a/skglm/penalties/separable.py
+++ b/skglm/penalties/separable.py
@@ -142,6 +142,93 @@ class L1_plus_L2(BasePenalty):
         return np.max(np.abs(gradient0))
 
 
+class WeightedL1_plus_L2(BasePenalty):
+    """Weighted :math:`ell_1 + ell_2` penalty (aka weighted ElasticNet penalty)."""
+
+    def __init__(self, alpha, l1_ratio, weights_l1, weights_l2, positive=False):
+        self.alpha = alpha
+        self.l1_ratio = l1_ratio
+        self.weights_l1 = weights_l1
+        self.weights_l2 = weights_l2
+        self.positive = positive
+
+    def get_spec(self):
+        spec = (
+            ('alpha', float64),
+            ('l1_ratio', float64),
+            ('weights_l1', float64[:]),
+            ('weights_l2', float64[:]),
+            ('positive', bool_),
+        )
+        return spec
+
+    def params_to_dict(self):
+        return dict(
+            alpha=self.alpha, l1_ratio=self.l1_ratio, weights_l1=self.weights_l1,
+            weights_l2=self.weights_l2, positive=self.positive)
+
+    def value(self, w):
+        """Compute the L1 + L2 penalty value."""
+        value = self.l1_ratio * self.alpha * np.sum(self.weights_l1 * np.abs(w))
+        value += (1 - self.l1_ratio) * self.alpha / 2 * np.sum(self.weights_l2 * w ** 2)
+        return value
+
+    def prox_1d(self, value, stepsize, j):
+        """Compute the proximal operator (scaled soft-thresholding)."""
+        prox = ST(value, self.l1_ratio * self.alpha * stepsize * self.weights_l1[j],
+                  self.positive)
+        prox /= (1 + stepsize * (1 - self.l1_ratio) * self.alpha * self.weights_l2[j])
+        return prox
+
+    def subdiff_distance(self, w, grad, ws):
+        """Compute distance of negative gradient to the subdifferential at w."""
+        subdiff_dist = np.zeros_like(grad)
+        alpha = self.alpha
+        l1_ratio = self.l1_ratio
+
+        for idx, j in enumerate(ws):
+            we1 = self.weights_l1[j]
+            we2 = self.weights_l2[j]
+            if self.positive:
+                if w[j] < 0:
+                    subdiff_dist[idx] = np.inf
+                elif w[j] == 0:
+                    # distance of -grad_j to (-infty, alpha * l1_ratio * we1]
+                    subdiff_dist[idx] = max(0, -grad[idx] - alpha * l1_ratio * we1)
+                else:
+                    # distance of -grad_j to alpha * {l1_ratio * we1 +
+                    #                                 (1 - l1_ratio) * we2 * w[j]}
+                    subdiff_dist[idx] = np.abs(
+                        grad[idx] + alpha * (l1_ratio * we1
+                                             + (1 - l1_ratio) * we2 * w[j]))
+            else:
+                if w[j] == 0:
+                    # distance of -grad_j to alpha * l1_ratio * we1 * [-1, 1]
+                    subdiff_dist[idx] = max(
+                        0, np.abs(grad[idx]) - alpha * l1_ratio * we1)
+                else:
+                    # distance of -grad_j to
+                    # {alpha * (l1 ratio * sign(w[j]) + (1 - l1_ratio) * w[j])}
+                    subdiff_dist[idx] = np.abs(
+                        grad[idx] + alpha * (l1_ratio * we1 * np.sign(w[j])
+                                             + (1 - l1_ratio) * we2 * w[j]))
+        return subdiff_dist
+
+    def is_penalized(self, n_features):
+        """Return a binary mask with the penalized features."""
+        return (self.weights_l1 != 0) * (self.weights_l2 != 0)
+
+    def generalized_support(self, w):
+        """Return a mask with non-zero coefficients."""
+        return w != 0
+
+    def alpha_max(self, gradient0):
+        """Return penalization value for which 0 is solution."""
+        # L2 part plays no role, same as WeightedL1
+        nnz_weights = self.weights_l1 != 0
+        return np.max(np.abs(gradient0[nnz_weights] / self.weights_l1[nnz_weights]))
+
+
 class WeightedL1(BasePenalty):
     """Weighted L1 penalty."""
 

--- a/skglm/tests/test_penalties.py
+++ b/skglm/tests/test_penalties.py
@@ -5,15 +5,16 @@ from numpy.linalg import norm
 from numpy.testing import assert_array_less
 
 from sklearn.linear_model import LinearRegression
+from sklearn.utils import check_random_state
 
 from skglm.datafits import Quadratic, QuadraticMultiTask
 from skglm.penalties import (
-    L1, L1_plus_L2, WeightedL1, MCPenalty, SCAD, IndicatorBox, L0_5, L2_3, SLOPE,
+    L1, L1_plus_L2, WeightedL1, WeightedL1_plus_L2, MCPenalty, SCAD, IndicatorBox,
+    L0_5, L2_3, SLOPE,
     LogSumPenalty, PositiveConstraint, L2_1, L2_05, BlockMCPenalty, BlockSCAD)
 from skglm import GeneralizedLinearEstimator, Lasso
 from skglm.solvers import AndersonCD, MultiTaskBCD, FISTA
 from skglm.utils.data import make_correlated_data
-
 from skglm.utils.prox_funcs import prox_log_sum, _log_sum_prox_val
 
 
@@ -31,10 +32,16 @@ alpha = alpha_max / 1000
 
 tol = 1e-10
 
+rng = check_random_state(0)
+weights_l1 = np.abs(rng.randn(n_features))
+weights_l2 = np.abs(rng.randn(n_features))
+
 penalties = [
     L1(alpha=alpha),
     L1_plus_L2(alpha=alpha, l1_ratio=0.5),
-    WeightedL1(alpha=1, weights=np.arange(n_features)),
+    WeightedL1(alpha=1, weights=weights_l1),
+    WeightedL1_plus_L2(alpha=1, weights_l1=weights_l1, weights_l2=weights_l2,
+                       l1_ratio=.8),
     MCPenalty(alpha=alpha, gamma=4),
     SCAD(alpha=alpha, gamma=4),
     IndicatorBox(alpha=alpha),


### PR DESCRIPTION
closes #338 

@Badr-MOUFAD should be straightforward to review: compared to L1_plus_L2, all `alpha * l1_ratio` become `alpha * l1_ratio * weight_l1[j]` and similarly `alpha * (1 - l1_ratio)` gets multiplied by `weights_l2[j]`